### PR TITLE
Initialize Flutter binding before background setup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'config/app_routes.dart';
 import 'package:intl/date_symbol_data_local.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting('id_ID', null);
   await JustAudioBackground.init(
     androidNotificationChannelId: 'com.ryanheise.bg_demo.channel.audio',


### PR DESCRIPTION
## Summary
- Ensure `WidgetsFlutterBinding.ensureInitialized()` is called before initializing date formatting and audio background plugins

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8d5f8a00832bb2d8918087763fa6