### PR TITLE
Add mounted check before setState in home screen

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -19,6 +19,7 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     Future.delayed(const Duration(seconds: 2), () {
+      if (!mounted) return;
       setState(() {
         isLoading = false;
       });


### PR DESCRIPTION
## Summary
- guard setState in HomeScreen with mounted check after delay

## Testing
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ad8d8167c4832badced760cc6713e7