### PR TITLE
Fix mini player import path for app routes

### DIFF
--- a/lib/widgets/mini_player.dart
+++ b/lib/widgets/mini_player.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import '../data/dummy_radio.dart';
 import '../audio/audio_player_manager.dart';
-import '../../../config/app_routes.dart';
+import '../config/app_routes.dart';
 
 class MiniPlayer extends StatefulWidget {
   const MiniPlayer({super.key});


### PR DESCRIPTION
## Summary
- fix mini player import for AppRoutes

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8d8bc074832b804c78364d28e397