### PR TITLE
feat: add environment-based API configuration

### DIFF
--- a/lib/config/app_api_config.dart
+++ b/lib/config/app_api_config.dart
@@ -1,4 +1,15 @@
 class AppApiConfig {
-  static const String baseUrl = "http://192.168.89.137:8000/api/v1/mobile";
-  static const String baseUrlStorage = "http://192.168.89.137:8000/storage";
+  /// Base URL for API requests. Can be overridden by passing
+  /// `--dart-define=BASE_URL=your_url` at build time.
+  static const String baseUrl = String.fromEnvironment(
+    'BASE_URL',
+    defaultValue: 'http://192.168.89.137:8000/api/v1/mobile',
+  );
+
+  /// Base URL for storage. Can be overridden by passing
+  /// `--dart-define=BASE_URL_STORAGE=your_url` at build time.
+  static const String baseUrlStorage = String.fromEnvironment(
+    'BASE_URL_STORAGE',
+    defaultValue: 'http://192.168.89.137:8000/storage',
+  );
 }

--- a/lib/services/artikel_service.dart
+++ b/lib/services/artikel_service.dart
@@ -1,13 +1,14 @@
 import 'package:dio/dio.dart';
+
 import '../config/app_api_config.dart';
 import '../models/artikel_model.dart';
 
 class ArtikelService {
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
 
   Future<List<Artikel>> fetchArtikel() async {
     try {
-      final response = await _dio.get("${AppApiConfig.baseUrl}/news");
+      final response = await _dio.get('/news');
 
       if (response.statusCode == 200 && response.data['status'] == true) {
         List<dynamic> artikelList = response.data['data'];

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -1,13 +1,14 @@
 import 'package:dio/dio.dart';
+
 import '../config/app_api_config.dart';
 import '../models/event_model.dart';
 
 class EventService {
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
 
   Future<List<Event>> fetchEvents() async {
     try {
-      final response = await _dio.get("${AppApiConfig.baseUrl}/event");
+      final response = await _dio.get('/event');
 
       if (response.statusCode == 200 && response.data['status'] == true) {
         List<dynamic> eventList = response.data['data'];

--- a/lib/services/login_service.dart
+++ b/lib/services/login_service.dart
@@ -1,13 +1,17 @@
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
+
 import '../config/app_api_config.dart';
 import '../models/login_model.dart';
 
 class AuthService {
+  final String _baseUrl = AppApiConfig.baseUrl;
+
   Future<AuthResponse?> loginWithGoogle(String idToken) async {
     try {
       final response = await http.post(
-        Uri.parse('${AppApiConfig.baseUrl}/login/google'),
+        Uri.parse('$_baseUrl/login/google'),
         body: {'token': idToken},
       );
 

--- a/lib/services/penyiar_service.dart
+++ b/lib/services/penyiar_service.dart
@@ -1,13 +1,14 @@
 import 'package:dio/dio.dart';
+
 import '../config/app_api_config.dart';
 import '../models/penyiar_model.dart';
 
 class PenyiarService {
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
 
   Future<List<Penyiar>> fetchPenyiar() async {
     try {
-      final response = await _dio.get("${AppApiConfig.baseUrl}/penyiar");
+      final response = await _dio.get('/penyiar');
 
       if (response.statusCode == 200 && response.data['status'] == true) {
         List<dynamic> penyiarList = response.data['data'];

--- a/lib/services/program_service.dart
+++ b/lib/services/program_service.dart
@@ -1,13 +1,14 @@
 import 'package:dio/dio.dart';
+
 import '../config/app_api_config.dart';
 import '../models/program_model.dart';
 
 class ProgramService {
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
 
   Future<List<Program>> fetchProgram() async {
     try {
-      final response = await _dio.get("${AppApiConfig.baseUrl}/program-siaran");
+      final response = await _dio.get('/program-siaran');
 
       if (response.statusCode == 200 && response.data['status'] == true) {
         List<dynamic> programList = response.data['data'];


### PR DESCRIPTION
## Summary
- load API base URLs from environment definitions
- use `AppApiConfig` base URL across services

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8da5d56c832bab79989522c3cc4a