### PR TITLE
Dispose audio player on app close and handle lifecycle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'config/app_theme.dart';
 import 'package:just_audio_background/just_audio_background.dart';
 import 'config/app_routes.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'audio/audio_player_manager.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -15,8 +16,39 @@ Future<void> main() async {
   runApp(MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
+  bool _wasPlaying = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    AudioPlayerManager().dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    final manager = AudioPlayerManager();
+    if (state == AppLifecycleState.paused) {
+      _wasPlaying = manager.player.playing;
+      manager.pause();
+    } else if (state == AppLifecycleState.resumed && _wasPlaying) {
+      manager.player.play();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- dispose AudioPlayerManager when the app shuts down
- handle app lifecycle with WidgetsBindingObserver, pausing and resuming playback

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8fafcd48832b964b1ec8fde669ca