### PR TITLE
Require external API URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,26 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Configuration
+
+The application requires API endpoints to be provided at runtime. Set `BASE_URL`
+and `BASE_URL_STORAGE` using either `--dart-define` when launching the app or a
+`.env` file in the project root.
+
+### Using `--dart-define`
+
+```bash
+flutter run \
+  --dart-define=BASE_URL=https://example.com/api/v1/mobile \
+  --dart-define=BASE_URL_STORAGE=https://example.com/storage
+```
+
+### Using a `.env` file
+
+Create a `.env` file in the project root:
+
+```env
+BASE_URL=https://example.com/api/v1/mobile
+BASE_URL_STORAGE=https://example.com/storage
+```

--- a/lib/config/app_api_config.dart
+++ b/lib/config/app_api_config.dart
@@ -1,15 +1,23 @@
-class AppApiConfig {
-  /// Base URL for API requests. Can be overridden by passing
-  /// `--dart-define=BASE_URL=your_url` at build time.
-  static const String baseUrl = String.fromEnvironment(
-    'BASE_URL',
-    defaultValue: 'http://192.168.89.137:8000/api/v1/mobile',
-  );
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-  /// Base URL for storage. Can be overridden by passing
-  /// `--dart-define=BASE_URL_STORAGE=your_url` at build time.
-  static const String baseUrlStorage = String.fromEnvironment(
-    'BASE_URL_STORAGE',
-    defaultValue: 'http://192.168.89.137:8000/storage',
-  );
+class AppApiConfig {
+  /// Base URL for API requests. Must be provided via
+  /// `--dart-define=BASE_URL=your_url` at build time or in a `.env` file.
+  static final String baseUrl = _getEnv('BASE_URL');
+
+  /// Base URL for storage. Must be provided via
+  /// `--dart-define=BASE_URL_STORAGE=your_url` at build time or in a `.env` file.
+  static final String baseUrlStorage = _getEnv('BASE_URL_STORAGE');
+
+  static String _getEnv(String key) {
+    const envValue = String.fromEnvironment(key);
+    if (envValue.isNotEmpty) return envValue;
+
+    final fileValue = dotenv.maybeGet(key);
+    if (fileValue != null && fileValue.isNotEmpty) return fileValue;
+
+    throw StateError(
+      '$key is not set. Provide it via --dart-define or in a .env file.',
+    );
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,9 +3,11 @@ import 'config/app_theme.dart';
 import 'package:just_audio_background/just_audio_background.dart';
 import 'config/app_routes.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: '.env');
   await initializeDateFormatting('id_ID', null);
   await JustAudioBackground.init(
     androidNotificationChannelId: 'com.ryanheise.bg_demo.channel.audio',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   intl: ^0.19.0
   google_sign_in: ^6.1.4
   http: ^1.2.2
+  flutter_dotenv: ^5.1.0
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Summary
- remove hardcoded default API URLs and load from --dart-define or .env
- add flutter_dotenv and load configuration at startup
- document runtime URL configuration in README

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8fbf4f94832bb134f75d9c490e28