### PR TITLE
Adjust login endpoint to new mobile API path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and `BASE_URL_STORAGE` using either `--dart-define` when launching the app or a
 
 ```bash
 flutter run \
-  --dart-define=BASE_URL=https://example.com/api/v1/mobile \
+  --dart-define=BASE_URL=https://example.com \
   --dart-define=BASE_URL_STORAGE=https://example.com/storage
 ```
 
@@ -34,6 +34,6 @@ flutter run \
 Create a `.env` file in the project root:
 
 ```env
-BASE_URL=https://example.com/api/v1/mobile
+BASE_URL=https://example.com
 BASE_URL_STORAGE=https://example.com/storage
 ```

--- a/lib/services/login_service.dart
+++ b/lib/services/login_service.dart
@@ -11,7 +11,7 @@ class AuthService {
   Future<AuthResponse?> login(String email, String password) async {
     try {
       final response = await http.post(
-        Uri.parse('$_baseUrl/login'),
+        Uri.parse('$_baseUrl/api/v1/mobile/login'),
         body: {'email': email, 'password': password},
       );
 


### PR DESCRIPTION
## Summary
- point login service to `/api/v1/mobile/login`
- document host-only `BASE_URL` configuration in README

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9e4b3b68832ba894cc420d190792