### PR TITLE
refactor: centralize api client

### DIFF
--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+
+import '../config/app_api_config.dart';
+
+/// Centralized API client using a single [Dio] instance.
+class ApiClient {
+  ApiClient._();
+
+  /// Shared [Dio] instance configured with base options.
+  static final Dio dio = Dio(
+    BaseOptions(
+      baseUrl: AppApiConfig.baseUrl,
+      connectTimeout: const Duration(seconds: 5),
+      receiveTimeout: const Duration(seconds: 5),
+    ),
+  );
+}
+

--- a/lib/services/artikel_service.dart
+++ b/lib/services/artikel_service.dart
@@ -1,10 +1,10 @@
 import 'package:dio/dio.dart';
 
-import '../config/app_api_config.dart';
 import '../models/artikel_model.dart';
+import 'api_client.dart';
 
 class ArtikelService {
-  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
+  final Dio _dio = ApiClient.dio;
 
   Future<List<Artikel>> fetchArtikel() async {
     try {

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -1,10 +1,10 @@
 import 'package:dio/dio.dart';
 
-import '../config/app_api_config.dart';
 import '../models/event_model.dart';
+import 'api_client.dart';
 
 class EventService {
-  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
+  final Dio _dio = ApiClient.dio;
 
   Future<List<Event>> fetchEvents() async {
     try {

--- a/lib/services/penyiar_service.dart
+++ b/lib/services/penyiar_service.dart
@@ -1,10 +1,10 @@
 import 'package:dio/dio.dart';
 
-import '../config/app_api_config.dart';
 import '../models/penyiar_model.dart';
+import 'api_client.dart';
 
 class PenyiarService {
-  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
+  final Dio _dio = ApiClient.dio;
 
   Future<List<Penyiar>> fetchPenyiar() async {
     try {

--- a/lib/services/program_service.dart
+++ b/lib/services/program_service.dart
@@ -1,10 +1,10 @@
 import 'package:dio/dio.dart';
 
-import '../config/app_api_config.dart';
 import '../models/program_model.dart';
+import 'api_client.dart';
 
 class ProgramService {
-  final Dio _dio = Dio(BaseOptions(baseUrl: AppApiConfig.baseUrl));
+  final Dio _dio = ApiClient.dio;
 
   Future<List<Program>> fetchProgram() async {
     try {

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,11 +1,12 @@
-import 'dart:convert';
-import 'package:http/http.dart' as http;
+import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../config/app_api_config.dart';
+
 import '../models/user_model.dart';
+import 'api_client.dart';
 
 class UserService {
   static const String _userKey = 'user_token';
+  static final Dio _dio = ApiClient.dio;
 
   // Ambil token dari SharedPreferences
   static Future<String?> _getToken() async {
@@ -34,25 +35,27 @@ class UserService {
         return null;
       }
 
-      final response = await http.get(
-        Uri.parse('${AppApiConfig.baseUrl}/user'),
-        headers: {
-          'Authorization': 'Bearer $token',
-          'Accept': 'application/json',
-        },
+      final response = await _dio.get(
+        '/user',
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $token',
+            'Accept': 'application/json',
+          },
+        ),
       );
 
       if (response.statusCode == 200) {
-        final body = jsonDecode(response.body);
+        final body = response.data;
 
         if (body['status'] == true && body['data'] != null) {
           // ✅ Ambil langsung object "data"
           return UserModel.fromJson(body['data']);
         } else {
-          print("API status false: ${response.body}");
+          print("API status false: ${response.data}");
         }
       } else {
-        print("Request gagal: ${response.statusCode} ${response.body}");
+        print("Request gagal: ${response.statusCode} ${response.data}");
       }
       return null;
     } catch (e) {


### PR DESCRIPTION
## Summary
- add ApiClient wrapping a shared Dio instance
- refactor services to use ApiClient for HTTP requests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adcc441ef8832b915475202a5222c1