### PR TITLE
feat: secure token storage and logout

### DIFF
--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,28 +1,46 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../config/app_api_config.dart';
 import '../models/user_model.dart';
 
 class UserService {
   static const String _userKey = 'user_token';
+  static const FlutterSecureStorage _storage = FlutterSecureStorage();
 
-  // Ambil token dari SharedPreferences
+  // Ambil token dari secure storage
   static Future<String?> _getToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_userKey);
+    return await _storage.read(key: _userKey);
   }
 
   // Simpan token setelah login
   static Future<void> saveToken(String token) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_userKey, token);
+    await _storage.write(key: _userKey, value: token);
   }
 
   // Hapus token saat logout
   static Future<void> clearToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_userKey);
+    await _storage.delete(key: _userKey);
+  }
+
+  // Logout dari API dan hapus token lokal
+  static Future<void> logout() async {
+    try {
+      final token = await _getToken();
+      if (token != null) {
+        await http.post(
+          Uri.parse('${AppApiConfig.baseUrl}/logout'),
+          headers: {
+            'Authorization': 'Bearer $token',
+            'Accept': 'application/json',
+          },
+        );
+      }
+    } catch (e) {
+      print('Error during logout: $e');
+    } finally {
+      await clearToken();
+    }
   }
 
   // Get user profile

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -744,62 +744,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  shared_preferences:
-    dependency: "direct main"
-    description:
-      name: shared_preferences
-      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.3"
-  shared_preferences_android:
-    dependency: transitive
-    description:
-      name: shared_preferences_android
-      sha256: "5bcf0772a761b04f8c6bf814721713de6f3e5d9d89caf8d3fe031b02a342379e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.11"
-  shared_preferences_foundation:
-    dependency: transitive
-    description:
-      name: shared_preferences_foundation
-      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.4"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.1"
-  shared_preferences_platform_interface:
-    dependency: transitive
-    description:
-      name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.1"
-  shared_preferences_web:
-    dependency: transitive
-    description:
-      name: shared_preferences_web
-      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.3"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.1"
   shimmer:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
   cached_network_image: ^3.3.1
   rxdart: ^0.27.7
   share_plus: ^11.0.0
-  shared_preferences: ^2.2.2
   image_picker: ^1.1.2
   dio: ^5.5.0
   flutter_secure_storage: ^9.2.2


### PR DESCRIPTION
## Summary
- migrate token storage to `flutter_secure_storage`
- add `logout` method to call API and clear token
- drop unused shared_preferences dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adcc4b16b4832b80aca6552b53e390