### PR TITLE
Check context mounted before navigation

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -32,8 +32,10 @@ class _LoginScreenState extends State<LoginScreen> {
 
     try {
       final authResponse = await AuthService().login(email, password);
+      if (!context.mounted) return;
       if (authResponse != null) {
         // ✅ Login sukses
+        if (!context.mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             backgroundColor: Colors.green.shade600,
@@ -51,10 +53,12 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
         );
 
+        if (!context.mounted) return;
         Navigator.pushReplacementNamed(context, AppRoutes.bottomNav);
       }
     } catch (e) {
       // ✅ Login gagal → tampilkan pesan dari API
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           backgroundColor: Colors.red.shade600,

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -40,6 +40,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
     final confirm = _confirmPasswordController.text;
 
     if (password != confirm) {
+      if (!context.mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Password tidak sama')));
@@ -48,8 +49,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
     final authResponse = await AuthService().register(name, email, password);
     if (authResponse != null) {
+      if (!context.mounted) return;
       Navigator.pushReplacementNamed(context, AppRoutes.bottomNav);
     } else {
+      if (!context.mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Registrasi gagal')));


### PR DESCRIPTION
## Summary
- guard `_login` and `_register` against unmounted context before navigation or snackbar use

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adcf5a8c00832b8ed9ad65f233b2f4