### PR TITLE
Show API success message after profile update

### DIFF
--- a/lib/screens/profile/edit_profile_screen.dart
+++ b/lib/screens/profile/edit_profile_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:dio/dio.dart';
 import 'package:radio_odan_app/models/user_model.dart';
 import 'package:radio_odan_app/services/user_service.dart';
 import 'package:radio_odan_app/config/logger.dart';
@@ -9,12 +8,9 @@ import 'package:radio_odan_app/config/app_api_config.dart';
 
 class EditProfileScreen extends StatefulWidget {
   final UserModel user;
-  final Function()? onProfileUpdated;
-
   const EditProfileScreen({
     super.key,
     required this.user,
-    this.onProfileUpdated,
   });
 
   @override
@@ -30,7 +26,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   File? _imageFile;
   final picker = ImagePicker();
   bool _isLoading = false;
-  final _formKey = GlobalKey<FormState>();
 
   @override
   void initState() {
@@ -89,14 +84,34 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   }
 
   Future<void> _updateProfile() async {
-    if (!_formKey.currentState!.validate()) return;
+    final name = _nameController.text.trim();
+    final email = _emailController.text.trim();
+
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Nama tidak boleh kosong'),
+          backgroundColor: Colors.red,
+        ),
+      );
+      return;
+    }
+    if (email.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Email tidak boleh kosong'),
+          backgroundColor: Colors.red,
+        ),
+      );
+      return;
+    }
 
     setState(() => _isLoading = true);
 
     try {
       final result = await UserService.updateProfile(
-        name: _nameController.text.trim(),
-        email: _emailController.text.trim(),
+        name: name,
+        email: email,
         phone: _phoneController.text.trim().isNotEmpty 
             ? _phoneController.text.trim() 
             : null,
@@ -109,29 +124,13 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       if (!mounted) return;
 
       if (result['success'] == true) {
-        // Update the user data in the parent widget
-        if (widget.onProfileUpdated != null) {
-          widget.onProfileUpdated!();
-        }
-        
-        // Show success message
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(result['message'] ?? 'Profil berhasil diperbarui'),
-              backgroundColor: Colors.green,
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-          
-          // Close the edit screen after a short delay
-          await Future.delayed(const Duration(seconds: 1));
-          if (mounted) {
-            Navigator.pop(context, true); // Pass true to indicate success
-          }
-        }
+        // Kembali ke ProfileScreen dengan pesan sukses dari API
+        Navigator.pop(
+          context,
+          result['message'] ?? 'Profil berhasil diperbarui',
+        );
       } else {
-        // Show error message if update was not successful
+        // Tampilkan pesan error jika gagal
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -258,10 +257,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton.icon(
-                  onPressed: () {
-                    // Simpan data (sementara balik ke profil)
-                    Navigator.pop(context);
-                  },
+                  onPressed: _isLoading ? null : _updateProfile,
                   icon: const Icon(Icons.save),
                   label: const Text("Simpan"),
                   style: ElevatedButton.styleFrom(

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -153,18 +153,22 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Future<void> _navigateToEditProfile() async {
     if (_user == null) return;
     
-    final result = await Navigator.push(
+    final message = await Navigator.push(
       context,
       MaterialPageRoute(
         builder: (context) => EditProfileScreen(
           user: _user!,
-          onProfileUpdated: _loadUserProfile,
         ),
       ),
     );
-    
-    // If the edit was successful (result is true), refresh the profile
-    if (result == true && mounted) {
+
+    if (message != null && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(message.toString()),
+          backgroundColor: Colors.green,
+        ),
+      );
       await _loadUserProfile();
     }
   }


### PR DESCRIPTION
## Summary
- Invoke update API when saving profile
- Return API message to profile screen and show snack bar
- Clean up unused form handling
- Validate required fields before updating profile

## Testing
- `dart format lib/screens/profile/edit_profile_screen.dart lib/screens/profile/profile_screen.dart` *(command not found)*
- `flutter test` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68adf613d6fc832b9c1a26b5fd943f07