### PR TITLE
fix: avoid SliverList layout crash with unique SizedBox instances

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -53,13 +53,16 @@ class _HomeScreenState extends State<HomeScreen> {
               padding: const EdgeInsets.only(top: 8, bottom: 80),
               sliver: SliverList(
                 delegate: SliverChildListDelegate([
-                  const SizedBox(height: 8),
+                  // The `SizedBox` widgets here are intentionally non-const
+                  // because using the same const instance multiple times in a
+                  // `SliverChildListDelegate` can cause layout issues.
+                  SizedBox(height: 8),
                   const PenyiarList(),
-                  const SizedBox(height: 24),
+                  SizedBox(height: 24),
                   const ProgramList(),
-                  const SizedBox(height: 24),
+                  SizedBox(height: 24),
                   const EventList(),
-                  const SizedBox(height: 24),
+                  SizedBox(height: 24),
                   const ArtikelList(),
                 ]),
               ),


### PR DESCRIPTION
## Summary
- avoid reentrant layout assertion by using unique non-const `SizedBox` widgets in `HomeScreen`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e09cf40832b9cf80155dafa178a