### PR TITLE
Prevent back navigation from login screen

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -130,8 +130,9 @@ class _LoginScreenState extends State<LoginScreen> {
 
     return WillPopScope(
       onWillPop: () async {
-        // Prevent going back to previous screen if it's the login screen
-        return !Navigator.of(context).userGestureInProgress;
+        // Stay on the login screen when the back button is pressed
+        // so users can't navigate to the previous route (e.g. home).
+        return false;
       },
       child: Scaffold(
         body: Stack(


### PR DESCRIPTION
## Summary
- prevent back button on login from navigating to previous route (home)

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3cb71928832b972f131ad17bee2e