### PR TITLE
Prevent back navigation from login screen

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -128,11 +128,8 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return WillPopScope(
-      onWillPop: () async {
-        // Prevent going back to previous screen if it's the login screen
-        return !Navigator.of(context).userGestureInProgress;
-      },
+    return PopScope(
+      canPop: false, // Prevent navigating back to previous routes like home
       child: Scaffold(
         body: Stack(
           children: [


### PR DESCRIPTION
## Summary
- disable back navigation from the login screen so users can't return to previous routes like home

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3cb71928832b972f131ad17bee2e