### PR TITLE
Fix column sizing in home list widgets

### DIFF
--- a/lib/screens/home/widgets/artikel_list.dart
+++ b/lib/screens/home/widgets/artikel_list.dart
@@ -50,6 +50,7 @@ class _ArtikelListState extends State<ArtikelList>
   Widget build(BuildContext context) {
     super.build(context); // WAJIB kalau pakai AutomaticKeepAliveClientMixin
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(

--- a/lib/screens/home/widgets/event_list.dart
+++ b/lib/screens/home/widgets/event_list.dart
@@ -49,6 +49,7 @@ class _EventListState extends State<EventList>
   Widget build(BuildContext context) {
     super.build(context); // wajib kalau pakai AutomaticKeepAliveClientMixin
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(

--- a/lib/screens/home/widgets/penyiar_list.dart
+++ b/lib/screens/home/widgets/penyiar_list.dart
@@ -49,6 +49,7 @@ class _PenyiarListState extends State<PenyiarList>
     super.build(context);
 
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Padding(

--- a/lib/screens/home/widgets/program_list.dart
+++ b/lib/screens/home/widgets/program_list.dart
@@ -47,6 +47,7 @@ class _ProgramListState extends State<ProgramList>
   Widget build(BuildContext context) {
     super.build(context); // WAJIB kalau pakai AutomaticKeepAlive
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(


### PR DESCRIPTION
## Summary
- ensure PenyiarList uses Column with MainAxisSize.min so height fits children
- ensure ProgramList uses Column with MainAxisSize.min
- ensure EventList uses Column with MainAxisSize.min
- ensure ArtikelList uses Column with MainAxisSize.min

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afb484ca70832ba402f169c680ea0f