### PR TITLE
Fix nested scrolling in event skeleton

### DIFF
--- a/lib/widgets/skeleton/event_skeleton.dart
+++ b/lib/widgets/skeleton/event_skeleton.dart
@@ -7,8 +7,14 @@ class EventSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The list is wrapped with `shrinkWrap` and non-scrollable physics so it can
+    // live inside another scrollable widget without causing layout issues. Make
+    // sure that a surrounding widget (e.g. a `Column` or `SizedBox`) provides
+    // adequate height if further scrolling is required.
     return ListView.builder(
       padding: const EdgeInsets.all(16),
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: 3,
       itemBuilder: (context, index) => const Padding(
         padding: EdgeInsets.only(bottom: 16.0),


### PR DESCRIPTION
## Summary
- prevent nested scrolling in event skeleton by using shrinkWrap and NeverScrollableScrollPhysics

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afb801c84c832bbce73da09bd8d4ef