### PR TITLE
refactor: avoid null check operator in event loader

### DIFF
--- a/lib/screens/event/all_events_screen.dart
+++ b/lib/screens/event/all_events_screen.dart
@@ -75,11 +75,12 @@ class _AllEventsScreenState extends State<AllEventsScreen> {
                         fit: BoxFit.cover,
                         loadingBuilder: (context, child, loadingProgress) {
                           if (loadingProgress == null) return child;
+                          final totalBytes = loadingProgress.expectedTotalBytes;
                           return Center(
                             child: CircularProgressIndicator(
-                              value: loadingProgress.expectedTotalBytes != null
+                              value: totalBytes != null
                                   ? loadingProgress.cumulativeBytesLoaded /
-                                      loadingProgress.expectedTotalBytes!
+                                      totalBytes
                                   : null,
                             ),
                           );


### PR DESCRIPTION
## Summary
- safely handle expectedTotalBytes when loading event images

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68afb80a3b98832baca77738ac5ceed0