### PR TITLE
Clarify EventSkeleton list usage

### DIFF
--- a/lib/widgets/skeleton/event_skeleton.dart
+++ b/lib/widgets/skeleton/event_skeleton.dart
@@ -7,10 +7,11 @@ class EventSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // The list is wrapped with `shrinkWrap` and non-scrollable physics so it can
-    // live inside another scrollable widget without causing layout issues. Make
-    // sure that a surrounding widget (e.g. a `Column` or `SizedBox`) provides
-    // adequate height if further scrolling is required.
+    // The list uses `shrinkWrap` and non-scrollable physics so it can live
+    // inside another scrollable widget without causing layout issues. When
+    // placing this skeleton inside a `Column` or `SliverList`, wrap it with a
+    // `SizedBox` of fixed height or use `Expanded` to provide the necessary
+    // vertical constraints.
     return ListView.builder(
       padding: const EdgeInsets.all(16),
       shrinkWrap: true,


### PR DESCRIPTION
## Summary
- document height constraints for `EventSkeleton`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afb8ea5238832b95920011f0c34268