### PR TITLE
Handle missing article slug

### DIFF
--- a/lib/services/artikel_service.dart
+++ b/lib/services/artikel_service.dart
@@ -76,17 +76,13 @@ class ArtikelService {
       print('Response data: ${response.data}');
       
       if (response.statusCode == 200) {
-        if (response.data['status'] == true) {
-          if (response.data['data'] != null) {
-            return Artikel.fromJson(response.data['data']);
-          } else {
-            throw Exception('Data artikel tidak ditemukan dalam respons');
-          }
+        if (response.data['status'] == true && response.data['data'] != null) {
+          return Artikel.fromJson(response.data['data']);
         } else {
-          throw Exception(response.data['message'] ?? 'Gagal mengambil detail artikel: Status false');
+          throw Exception(response.data['message'] ?? 'Artikel tidak ada');
         }
       } else if (response.statusCode == 404) {
-        throw Exception('Artikel tidak ditemukan (404)');
+        throw Exception('Artikel tidak ada');
       } else {
         throw Exception('Gagal mengambil detail artikel. Kode status: ${response.statusCode}');
       }


### PR DESCRIPTION
## Summary
- confirm `fetchArtikelBySlug` uses the `/news/<slug>` endpoint
- handle missing article slug with clear "Artikel tidak ada" message

## Testing
- `dart format lib/services/artikel_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68affb71eb3c832b9f78bffe7d5c7b6d