### PR TITLE
refactor artikel list provider access

### DIFF
--- a/lib/screens/home/widgets/artikel_list.dart
+++ b/lib/screens/home/widgets/artikel_list.dart
@@ -35,9 +35,10 @@ class _ArtikelListState extends State<ArtikelList>
   Widget build(BuildContext context) {
     super.build(context); // WAJIB kalau pakai AutomaticKeepAliveClientMixin
 
-    final isLoading = context.watch<ArtikelProvider>().isLoading;
-    final artikelList = context.watch<ArtikelProvider>().artikels;
-    final error = context.watch<ArtikelProvider>().error;
+    final provider = context.watch<ArtikelProvider>();
+    final isLoading = provider.isLoading;
+    final artikelList = provider.artikels;
+    final error = provider.error;
 
     // Handle error
     if (error != null) {


### PR DESCRIPTION
## Summary
- avoid duplicate provider lookups in ArtikelList widget

## Testing
- `flutter format lib/screens/home/widgets/artikel_list.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68affbdcff3c832b8d0a0ad3cfb530b4