### PR TITLE
Always fetch latest data from API

### DIFF
--- a/lib/providers/artikel_provider.dart
+++ b/lib/providers/artikel_provider.dart
@@ -52,8 +52,8 @@ class ArtikelProvider with ChangeNotifier {
   }
 
   // Fetch initial list of articles with pagination
-  Future<void> fetchArtikels({bool forceRefresh = false}) async {
-    if ((_artikels.isNotEmpty && !forceRefresh) || _isLoading) return;
+  Future<void> fetchArtikels() async {
+    if (_isLoading) return;
 
     _isLoading = true;
     _error = null;

--- a/lib/providers/event_provider.dart
+++ b/lib/providers/event_provider.dart
@@ -20,13 +20,8 @@ class EventProvider with ChangeNotifier {
   bool get hasMore => _hasMore;
   String? get error => _error;
 
-  Future<void> fetchEvents({bool forceRefresh = false}) async {
-    if (_isLoadingMore) return;
-
-    // Jika sudah ada data dan bukan force refresh, tidak perlu fetch ulang
-    if (_events.isNotEmpty && !forceRefresh) {
-      return;
-    }
+  Future<void> fetchEvents() async {
+    if (_isLoading || _isLoadingMore) return;
 
     _isLoading = true;
     _page = 1;

--- a/lib/providers/penyiar_provider.dart
+++ b/lib/providers/penyiar_provider.dart
@@ -12,11 +12,8 @@ class PenyiarProvider with ChangeNotifier {
   bool get isLoading => _isLoading;
   String? get error => _error;
 
-  Future<void> fetchPenyiars({bool forceRefresh = false}) async {
-    // Jika sudah ada data dan bukan force refresh, tidak perlu fetch ulang
-    if (_penyiars.isNotEmpty && !forceRefresh) {
-      return;
-    }
+  Future<void> fetchPenyiars() async {
+    if (_isLoading) return;
 
     _isLoading = true;
     _error = null;

--- a/lib/screens/artikel/artikel_screen.dart
+++ b/lib/screens/artikel/artikel_screen.dart
@@ -22,12 +22,10 @@ class _ArtikelScreenState extends State<ArtikelScreen> {
     super.initState();
     _scrollController.addListener(_onScroll);
 
-    // Fetch initial data
+    // Fetch initial data every time screen is opened
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = context.read<ArtikelProvider>();
-      if (provider.artikels.isEmpty) {
-        provider.fetchArtikels();
-      }
+      provider.fetchArtikels();
     });
   }
 
@@ -134,7 +132,7 @@ class _ArtikelScreenState extends State<ArtikelScreen> {
     }
 
     return RefreshIndicator(
-      onRefresh: () => provider.fetchArtikels(forceRefresh: true),
+      onRefresh: () => provider.fetchArtikels(),
       child: ListView.builder(
         controller: _scrollController,
         padding: const EdgeInsets.all(16),

--- a/lib/screens/event/all_events_screen.dart
+++ b/lib/screens/event/all_events_screen.dart
@@ -16,7 +16,6 @@ class AllEventsScreen extends StatefulWidget {
 
 class _AllEventsScreenState extends State<AllEventsScreen> {
   final ScrollController _scrollController = ScrollController();
-  bool _isInitialized = false;
 
   @override
   void initState() {
@@ -25,12 +24,7 @@ class _AllEventsScreenState extends State<AllEventsScreen> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = context.read<EventProvider>();
-      if (!_isInitialized) {
-        _isInitialized = true;
-        if (provider.events.isEmpty) {
-          provider.fetchEvents();
-        }
-      }
+      provider.fetchEvents();
     });
   }
 

--- a/lib/screens/galeri/all_albums_screen.dart
+++ b/lib/screens/galeri/all_albums_screen.dart
@@ -22,10 +22,7 @@ class _AllAlbumsScreenState extends State<AllAlbumsScreen> {
     _scrollController.addListener(_onScroll);
     // Fetch initial data with a slight delay to allow build to complete
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final provider = context.read<AlbumProvider>();
-      if (provider.allAlbums.isEmpty) {
-        provider.fetchAllAlbums();
-      }
+      context.read<AlbumProvider>().fetchAllAlbums();
     });
   }
 

--- a/lib/screens/galeri/all_videos_screen.dart
+++ b/lib/screens/galeri/all_videos_screen.dart
@@ -34,9 +34,7 @@ class _AllVideosScreenState extends State<AllVideosScreen> {
 
   Future<void> _loadInitialVideos() async {
     final videoProvider = context.read<VideoProvider>();
-    if (videoProvider.allVideos.isEmpty) {
-      await videoProvider.fetchAllVideos();
-    }
+    await videoProvider.fetchAllVideos();
   }
 
   Future<void> _onRefresh() async {

--- a/lib/screens/galeri/widget/album_list.dart
+++ b/lib/screens/galeri/widget/album_list.dart
@@ -19,10 +19,7 @@ class _AlbumListState extends State<AlbumList> {
     super.initState();
     // Fetch albums when the widget is first created
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final albumProvider = context.read<AlbumProvider>();
-      if (!albumProvider.hasFeaturedAlbums) {
-        albumProvider.fetchFeaturedAlbums();
-      }
+      context.read<AlbumProvider>().fetchFeaturedAlbums();
     });
   }
 

--- a/lib/screens/galeri/widget/video_list.dart
+++ b/lib/screens/galeri/widget/video_list.dart
@@ -20,10 +20,7 @@ class _VideoListState extends State<VideoList> {
     super.initState();
     // Fetch videos when the widget is first created
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final videoProvider = context.read<VideoProvider>();
-      if (videoProvider.recentVideos.isEmpty) {
-        videoProvider.fetchRecentVideos();
-      }
+      context.read<VideoProvider>().fetchRecentVideos();
     });
   }
 

--- a/lib/screens/home/widgets/artikel_list.dart
+++ b/lib/screens/home/widgets/artikel_list.dart
@@ -22,12 +22,10 @@ class _ArtikelListState extends State<ArtikelList>
   @override
   void initState() {
     super.initState();
-    // Load recent articles
+    // Always load recent articles when the widget is created
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = Provider.of<ArtikelProvider>(context, listen: false);
-      if (provider.recentArtikels.isEmpty) {
-        provider.fetchRecentArtikels();
-      }
+      provider.fetchRecentArtikels();
     });
   }
 

--- a/lib/screens/home/widgets/event_list.dart
+++ b/lib/screens/home/widgets/event_list.dart
@@ -21,12 +21,10 @@ class _EventListState extends State<EventList>
   @override
   void initState() {
     super.initState();
-    // Load data hanya jika belum dimuat
+    // Always fetch events when the widget is created
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = Provider.of<EventProvider>(context, listen: false);
-      if (provider.events.isEmpty) {
-        provider.fetchEvents();
-      }
+      provider.fetchEvents();
     });
   }
 

--- a/lib/screens/home/widgets/penyiar_list.dart
+++ b/lib/screens/home/widgets/penyiar_list.dart
@@ -20,12 +20,10 @@ class _PenyiarListState extends State<PenyiarList>
   @override
   void initState() {
     super.initState();
-    // Load data hanya jika belum dimuat
+    // Always fetch presenters when the widget is created
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = Provider.of<PenyiarProvider>(context, listen: false);
-      if (provider.penyiars.isEmpty) {
-        provider.fetchPenyiars();
-      }
+      provider.fetchPenyiars();
     });
   }
 

--- a/lib/screens/home/widgets/program_list.dart
+++ b/lib/screens/home/widgets/program_list.dart
@@ -23,10 +23,7 @@ class _ProgramListState extends State<ProgramList>
     super.initState();
     // Fetch program only once when first initialized
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final provider = context.read<ProgramProvider>();
-      if (provider.todaysPrograms.isEmpty) {
-        provider.fetchTodaysPrograms();
-      }
+      context.read<ProgramProvider>().fetchTodaysPrograms();
     });
   }
 

--- a/lib/screens/program/all_programs_screen.dart
+++ b/lib/screens/program/all_programs_screen.dart
@@ -31,17 +31,13 @@ class _AllProgramsScreenState extends State<AllProgramsScreen> {
 
   Future<void> _loadInitialData() async {
     final provider = context.read<ProgramProvider>();
-    
-    // Only fetch if we don't have any data and not already loading
-    if (provider.allPrograms.isEmpty && !provider.isLoadingAll) {
-      try {
-        await provider.fetchAllPrograms();
-      } catch (e) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Gagal memuat daftar program')),
-          );
-        }
+    try {
+      await provider.fetchAllPrograms();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Gagal memuat daftar program')),
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- Remove leftover cache checks so gallery, video, and program screens always reload data from the API
- Ensure home widgets for albums, videos, and programs trigger fresh fetches on initialization

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b035bbb650832b9ac879901d3f45b3