### PR TITLE
feat: refresh data on screen focus

### DIFF
--- a/lib/screens/home/widgets/penyiar_list.dart
+++ b/lib/screens/home/widgets/penyiar_list.dart
@@ -65,16 +65,17 @@ class _PenyiarListState extends State<PenyiarList>
   
   Future<void> _checkAndRefresh() async {
     if (!mounted) return;
-    
-    final currentItems = context.read<PenyiarProvider>().items;
-    final shouldRefresh = _lastItems == null || 
-                         !const DeepCollectionEquality().equals(_lastItems, currentItems);
-    
+
+    final provider = context.read<PenyiarProvider>();
+    final currentItems = provider.items;
+    final shouldRefresh = _lastItems == null ||
+        !const DeepCollectionEquality().equals(_lastItems, currentItems);
+
     if (shouldRefresh) {
-      await context.read<PenyiarProvider>().refresh();
+      await provider.refresh();
       if (mounted) {
         setState(() {
-          _lastItems = List<Penyiar>.from(currentItems);
+          _lastItems = List<Penyiar>.from(provider.items);
         });
       }
     }

--- a/lib/screens/program/all_programs_screen.dart
+++ b/lib/screens/program/all_programs_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:collection/collection.dart';
 
 import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/models/program_model.dart';
@@ -16,50 +17,79 @@ class AllProgramsScreen extends StatefulWidget {
   State<AllProgramsScreen> createState() => _AllProgramsScreenState();
 }
 
-class _AllProgramsScreenState extends State<AllProgramsScreen> {
+class _AllProgramsScreenState extends State<AllProgramsScreen>
+    with WidgetsBindingObserver {
   final ScrollController _scrollController = ScrollController();
   bool _isLoadingMore = false;
-  bool _isInitialized = false;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (!_isInitialized) {
-      _isInitialized = true;
-      _loadInitialData();
-    }
-  }
-
-  Future<void> _loadInitialData() async {
-    final provider = context.read<ProgramProvider>();
-    try {
-      // Hanya fetch kalau masih kosong (biar nggak dobel sama init() di main.dart)
-      if (provider.allPrograms.isEmpty && !provider.isLoadingAll) {
-        await provider.fetchAllPrograms();
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Gagal memuat daftar program')),
-        );
-      }
-    }
-  }
+  bool _isMounted = false;
+  List<Program>? _lastItems;
 
   @override
   void initState() {
     super.initState();
+    _isMounted = true;
     _scrollController.addListener(_onScroll);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _loadData();
+      }
+    });
+
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  Future<void> _loadData() async {
+    final provider = context.read<ProgramProvider>();
+    await provider.fetchAllPrograms(forceRefresh: true);
+    _lastItems = List<Program>.from(provider.allPrograms);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _checkAndRefresh();
+      }
+    });
   }
 
   @override
   void dispose() {
+    _isMounted = false;
+    WidgetsBinding.instance.removeObserver(this);
     _scrollController.dispose();
     super.dispose();
   }
 
+  Future<void> _checkAndRefresh() async {
+    if (!mounted) return;
+
+    final provider = context.read<ProgramProvider>();
+    final currentItems = provider.allPrograms;
+    final shouldRefresh = _lastItems == null ||
+        !const DeepCollectionEquality().equals(_lastItems, currentItems);
+
+    if (shouldRefresh) {
+      await provider.fetchAllPrograms(forceRefresh: true);
+      if (mounted) {
+        setState(() {
+          _lastItems = List<Program>.from(provider.allPrograms);
+        });
+      }
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && _isMounted) {
+      _checkAndRefresh();
+    }
+  }
+
   void _onScroll() {
-    if (_scrollController.position.pixels ==
+    if (_scrollController.position.pixels >=
         _scrollController.position.maxScrollExtent) {
       _loadMorePrograms();
     }


### PR DESCRIPTION
## Summary
- add lifecycle-aware refresh for Artikel, Event, Program lists
- ensure All Events and All Programs screens reload when revisited
- fix penyiar list refresh logic and program list scroll detection

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b260cea64c832b9579a6352634c02e