### PR TITLE
feat: refresh data on screen focus

### DIFF
--- a/lib/screens/home/widgets/penyiar_list.dart
+++ b/lib/screens/home/widgets/penyiar_list.dart
@@ -65,16 +65,17 @@ class _PenyiarListState extends State<PenyiarList>
   
   Future<void> _checkAndRefresh() async {
     if (!mounted) return;
-    
-    final currentItems = context.read<PenyiarProvider>().items;
-    final shouldRefresh = _lastItems == null || 
-                         !const DeepCollectionEquality().equals(_lastItems, currentItems);
-    
+
+    final provider = context.read<PenyiarProvider>();
+    final currentItems = provider.items;
+    final shouldRefresh = _lastItems == null ||
+        !const DeepCollectionEquality().equals(_lastItems, currentItems);
+
     if (shouldRefresh) {
-      await context.read<PenyiarProvider>().refresh();
+      await provider.refresh();
       if (mounted) {
         setState(() {
-          _lastItems = List<Penyiar>.from(currentItems);
+          _lastItems = List<Penyiar>.from(provider.items);
         });
       }
     }


### PR DESCRIPTION
## Summary
- add lifecycle-aware refresh for Artikel, Event, Program lists
- ensure All Events and All Programs screens reload when revisited
- fix penyiar list refresh logic and program list scroll detection
- correct All Programs retry button to use existing load routine

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b260cea64c832b9579a6352634c02e