### PR TITLE
Schedule user data load after initial build

### DIFF
--- a/lib/widgets/app_header.dart
+++ b/lib/widgets/app_header.dart
@@ -35,7 +35,7 @@ class _AppHeaderState extends State<AppHeader> with WidgetsBindingObserver {
     super.initState();
     _isMounted = true;
     WidgetsBinding.instance.addObserver(this);
-    _loadUserData();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadUserData());
   }
 
   @override


### PR DESCRIPTION
## Summary
- defer user data fetching until after first frame to avoid build-phase notifyListeners

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b26403ce3c832b9fc651f83b2efcb7