### PR TITLE
Enable background radio streaming with fresh resume

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,31 +41,12 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
-  bool _wasPlaying = false;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-  }
-
+class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    // Dispose the audio player when the app is terminated
     AudioPlayerManager().dispose();
     super.dispose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    final manager = AudioPlayerManager();
-    if (state == AppLifecycleState.paused) {
-      _wasPlaying = manager.player.playing;
-      manager.pause();
-    } else if (state == AppLifecycleState.resumed && _wasPlaying) {
-      manager.player.play();
-    }
   }
 
   @override

--- a/lib/providers/radio_station_provider.dart
+++ b/lib/providers/radio_station_provider.dart
@@ -57,7 +57,8 @@ class RadioStationProvider with ChangeNotifier {
     try {
       if (_isPlaying) {
         log('Pausing playback');
-        await _audioManager.pause();
+        // Stop completely so that resuming fetches fresh audio and avoids delay
+        await _audioManager.stop();
         _isPlaying = false;
       } else {
         log('Starting playback for ${_currentStation!.title}');

--- a/lib/screens/full_player/full_player.dart
+++ b/lib/screens/full_player/full_player.dart
@@ -44,12 +44,6 @@ class _FullPlayerState extends State<FullPlayer> {
   }
 
   @override
-  void dispose() {
-    _audioManager.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final radioProvider = Provider.of<RadioStationProvider>(context);
     final currentStation = radioProvider.currentStation;


### PR DESCRIPTION
## Summary
- keep audio player running across screens by not disposing the global manager
- allow background playback by removing lifecycle pause logic
- reload stream after pause by stopping playback to fetch fresh audio

## Testing
- `dart format lib/screens/full_player/full_player.dart lib/providers/radio_station_provider.dart lib/main.dart` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3618d58d4832bb7713bc31a315d73