### PR TITLE
Display now playing metadata in players

### DIFF
--- a/lib/models/now_playing.dart
+++ b/lib/models/now_playing.dart
@@ -1,0 +1,20 @@
+class NowPlayingInfo {
+  final String title;
+  final String artist;
+  final String artUrl;
+
+  const NowPlayingInfo({
+    required this.title,
+    required this.artist,
+    required this.artUrl,
+  });
+
+  factory NowPlayingInfo.fromJson(Map<String, dynamic> json) {
+    final song = (json['now_playing'] ?? const {})['song'] ?? const {};
+    return NowPlayingInfo(
+      title: song['title']?.toString() ?? '',
+      artist: song['artist']?.toString() ?? '',
+      artUrl: song['art']?.toString() ?? '',
+    );
+  }
+}

--- a/lib/models/radio_station.dart
+++ b/lib/models/radio_station.dart
@@ -3,11 +3,13 @@ class RadioStation {
   final String host;
   final String coverUrl;
   final String streamUrl;
+  final String nowPlayingUrl;
 
   RadioStation({
     required this.title,
     required this.host,
     required this.coverUrl,
     required this.streamUrl,
+    required this.nowPlayingUrl,
   });
 }

--- a/lib/screens/full_player/full_player.dart
+++ b/lib/screens/full_player/full_player.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:provider/provider.dart';
@@ -48,6 +49,17 @@ class _FullPlayerState extends State<FullPlayer> {
   Widget build(BuildContext context) {
     final radioProvider = Provider.of<RadioStationProvider>(context);
     final currentStation = radioProvider.currentStation;
+    final nowPlaying = radioProvider.nowPlaying;
+
+    final cover = (nowPlaying?.artUrl.isNotEmpty ?? false)
+        ? nowPlaying!.artUrl
+        : currentStation?.coverUrl ?? '';
+    final title = (nowPlaying?.title.isNotEmpty ?? false)
+        ? nowPlaying!.title
+        : currentStation?.title ?? '';
+    final artist = (nowPlaying?.artist.isNotEmpty ?? false)
+        ? nowPlaying!.artist
+        : currentStation?.host ?? '';
 
     if (currentStation == null) {
       return const Scaffold(
@@ -96,11 +108,17 @@ class _FullPlayerState extends State<FullPlayer> {
                   padding: const EdgeInsets.all(30.0),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(12),
-                    child: Image.asset(
-                      currentStation.coverUrl,
-                      width: double.infinity,
-                      fit: BoxFit.cover,
-                    ),
+                    child: (nowPlaying?.artUrl.isNotEmpty ?? false)
+                        ? CachedNetworkImage(
+                            imageUrl: cover,
+                            width: double.infinity,
+                            fit: BoxFit.cover,
+                          )
+                        : Image.asset(
+                            cover,
+                            width: double.infinity,
+                            fit: BoxFit.cover,
+                          ),
                   ),
                 ),
               ),
@@ -113,7 +131,7 @@ class _FullPlayerState extends State<FullPlayer> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text(
-                    currentStation.title,
+                    title,
                     style: const TextStyle(
                       fontSize: 22,
                       fontWeight: FontWeight.bold,
@@ -123,7 +141,7 @@ class _FullPlayerState extends State<FullPlayer> {
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    currentStation.host,
+                    artist,
                     style: const TextStyle(fontSize: 14, color: Colors.grey),
                   ),
                   const SizedBox(height: 16),

--- a/lib/widgets/mini_player.dart
+++ b/lib/widgets/mini_player.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:provider/provider.dart';
@@ -26,6 +27,17 @@ class _MiniPlayerState extends State<MiniPlayer> {
     final radioProvider = Provider.of<RadioStationProvider>(context);
     final currentStation =
         radioProvider.currentStation ?? RadioStationProvider.defaultStation;
+    final nowPlaying = radioProvider.nowPlaying;
+
+    final cover = (nowPlaying?.artUrl.isNotEmpty ?? false)
+        ? nowPlaying!.artUrl
+        : currentStation.coverUrl;
+    final title = (nowPlaying?.title.isNotEmpty ?? false)
+        ? nowPlaying!.title
+        : currentStation.title;
+    final artist = (nowPlaying?.artist.isNotEmpty ?? false)
+        ? nowPlaying!.artist
+        : currentStation.host;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -56,12 +68,19 @@ class _MiniPlayerState extends State<MiniPlayer> {
                 children: [
                   ClipRRect(
                     borderRadius: BorderRadius.circular(6),
-                    child: Image.asset(
-                      currentStation.coverUrl,
-                      height: 42,
-                      width: 42,
-                      fit: BoxFit.cover,
-                    ),
+                    child: (nowPlaying?.artUrl.isNotEmpty ?? false)
+                        ? CachedNetworkImage(
+                            imageUrl: cover,
+                            height: 42,
+                            width: 42,
+                            fit: BoxFit.cover,
+                          )
+                        : Image.asset(
+                            cover,
+                            height: 42,
+                            width: 42,
+                            fit: BoxFit.cover,
+                          ),
                   ),
                   const SizedBox(width: 12),
                   Expanded(
@@ -70,7 +89,7 @@ class _MiniPlayerState extends State<MiniPlayer> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          currentStation.title,
+                          title,
                           style: const TextStyle(
                             color: Colors.white,
                             fontWeight: FontWeight.w600,
@@ -79,7 +98,7 @@ class _MiniPlayerState extends State<MiniPlayer> {
                           overflow: TextOverflow.ellipsis,
                         ),
                         Text(
-                          currentStation.host,
+                          artist,
                           style: const TextStyle(
                             color: Colors.grey,
                             fontSize: 12,


### PR DESCRIPTION
## Summary
- add model for station now-playing response
- fetch now-playing info periodically in provider
- show live song title, artist, and artwork in mini and full players

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b367e84d60832bb1fa95c778617e2e