### PR TITLE
Switch now playing to WebSocket

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   html: ^0.15.4
   url_launcher: ^6.2.5
   shared_preferences: ^2.2.2
+  web_socket_channel: ^2.4.0
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Summary
- use WebSocket channel to stream now-playing updates
- depend on `web_socket_channel` for WebSocket support

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b372b990d0832ba0c182357d5201d7