### PR TITLE
Keep audio playing when closing full player

### DIFF
--- a/lib/screens/full_player/full_player.dart
+++ b/lib/screens/full_player/full_player.dart
@@ -33,12 +33,6 @@ class _FullPlayerState extends State<FullPlayer> {
     _initializePlayer();
   }
 
-  @override
-  void dispose() {
-    _audioManager.dispose();
-    super.dispose();
-  }
-
   Future<void> _initializePlayer() async {
     try {
       final radioProvider = Provider.of<RadioStationProvider>(


### PR DESCRIPTION
## Summary
- avoid disposing shared AudioPlayerManager when leaving the full player

## Testing
- `dart format lib/screens/full_player/full_player.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b387b7f980832bb7babbc88fefbce6