### PR TITLE
feat: integrate live chat with pusher

### DIFF
--- a/lib/config/pusher_config.dart
+++ b/lib/config/pusher_config.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class PusherConfig {
+  static String get appKey {
+    final key = dotenv.maybeGet('PUSHER_APP_KEY');
+    if (key == null || key.isEmpty) {
+      throw Exception('PUSHER_APP_KEY tidak ditemukan di .env');
+    }
+    return key;
+  }
+
+  static String get cluster {
+    final cluster = dotenv.maybeGet('PUSHER_CLUSTER');
+    if (cluster == null || cluster.isEmpty) {
+      throw Exception('PUSHER_CLUSTER tidak ditemukan di .env');
+    }
+    return cluster;
+  }
+
+  static String get authEndpoint {
+    final endpoint = dotenv.maybeGet('BROADCAST_AUTH_ENDPOINT');
+    if (endpoint == null || endpoint.isEmpty) {
+      return '/broadcasting/auth';
+    }
+    return endpoint;
+  }
+}

--- a/lib/models/live_chat_message.dart
+++ b/lib/models/live_chat_message.dart
@@ -1,0 +1,34 @@
+import '../config/app_api_config.dart';
+
+class LiveChatMessage {
+  final int id;
+  final String message;
+  final int userId;
+  final String name;
+  final String avatar;
+  final DateTime timestamp;
+
+  LiveChatMessage({
+    required this.id,
+    required this.message,
+    required this.userId,
+    required this.name,
+    required this.avatar,
+    required this.timestamp,
+  });
+
+  factory LiveChatMessage.fromJson(Map<String, dynamic> json) {
+    String avatar = json['avatar']?.toString() ?? '';
+    if (avatar.isNotEmpty && !avatar.startsWith('http')) {
+      avatar = '${AppApiConfig.apiBaseUrl}/storage/${avatar.startsWith('/') ? avatar.substring(1) : avatar}';
+    }
+    return LiveChatMessage(
+      id: json['id'] as int,
+      message: json['message']?.toString() ?? '',
+      userId: json['user_id'] as int,
+      name: json['name']?.toString() ?? '',
+      avatar: avatar,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+}

--- a/lib/models/live_chat_status.dart
+++ b/lib/models/live_chat_status.dart
@@ -1,0 +1,62 @@
+class LiveChatStatus {
+  final bool isLive;
+  final String title;
+  final String description;
+  final DateTime? startedAt;
+  final int likes;
+  final bool liked;
+  final int listenerCount;
+
+  LiveChatStatus({
+    required this.isLive,
+    required this.title,
+    required this.description,
+    required this.startedAt,
+    required this.likes,
+    required this.liked,
+    required this.listenerCount,
+  });
+
+  factory LiveChatStatus.fromJson(Map<String, dynamic> json) {
+    DateTime? started;
+    final raw = json['started_at'];
+    if (raw is String && raw.isNotEmpty) {
+      try {
+        started = DateTime.parse(raw);
+      } catch (_) {}
+    }
+    return LiveChatStatus(
+      isLive: json['is_live'] == true,
+      title: json['title']?.toString() ?? '',
+      description: json['description']?.toString() ?? '',
+      startedAt: started,
+      likes: json['likes'] is int
+          ? json['likes']
+          : int.tryParse(json['likes']?.toString() ?? '') ?? 0,
+      liked: json['liked'] == true,
+      listenerCount: json['listener_count'] is int
+          ? json['listener_count']
+          : int.tryParse(json['listener_count']?.toString() ?? '') ?? 0,
+    );
+  }
+
+  LiveChatStatus copyWith({
+    bool? isLive,
+    String? title,
+    String? description,
+    DateTime? startedAt,
+    int? likes,
+    bool? liked,
+    int? listenerCount,
+  }) {
+    return LiveChatStatus(
+      isLive: isLive ?? this.isLive,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      startedAt: startedAt ?? this.startedAt,
+      likes: likes ?? this.likes,
+      liked: liked ?? this.liked,
+      listenerCount: listenerCount ?? this.listenerCount,
+    );
+  }
+}

--- a/lib/services/live_chat_service.dart
+++ b/lib/services/live_chat_service.dart
@@ -1,0 +1,74 @@
+import 'package:dio/dio.dart';
+
+import '../config/api_client.dart';
+import '../models/live_chat_message.dart';
+import '../models/live_chat_status.dart';
+
+class LiveChatService {
+  LiveChatService._();
+  static final LiveChatService I = LiveChatService._();
+
+  final Dio _dio = ApiClient.I.dio;
+
+  Future<List<LiveChatMessage>> fetchMessages(int id) async {
+    final res = await _dio.get('/live-chat/$id/fetch');
+    final body = Map<String, dynamic>.from(res.data);
+    if (body['success'] == true && body['data'] is List) {
+      final list = List<Map<String, dynamic>>.from(body['data']);
+      return list.map(LiveChatMessage.fromJson).toList();
+    }
+    throw Exception(body['message'] ?? 'Gagal mengambil pesan');
+  }
+
+  Future<LiveChatStatus> fetchStatus(int id) async {
+    final res = await _dio.get('/live-chat/$id/status');
+    final body = Map<String, dynamic>.from(res.data);
+    if (body['success'] == true && body['data'] is Map) {
+      return LiveChatStatus.fromJson(Map<String, dynamic>.from(body['data']));
+    }
+    throw Exception(body['message'] ?? 'Gagal mengambil status');
+  }
+
+  Future<LiveChatMessage> sendMessage(int id, String text) async {
+    final res = await _dio.post('/live-chat/$id/send', data: {'message': text});
+    final body = Map<String, dynamic>.from(res.data);
+    if (body['success'] == true && body['data'] is Map) {
+      return LiveChatMessage.fromJson(Map<String, dynamic>.from(body['data']));
+    }
+    throw Exception(body['message'] ?? 'Gagal mengirim pesan');
+  }
+
+  Future<Map<String, dynamic>> toggleLike(int id) async {
+    final res = await _dio.post('/live-chat/$id/like-toggle');
+    final data = Map<String, dynamic>.from(res.data);
+    return {
+      'liked': data['liked'] == true,
+      'likes': data['likes'] is int
+          ? data['likes']
+          : int.tryParse(data['likes']?.toString() ?? '') ?? 0,
+    };
+  }
+
+  Future<Map<String, dynamic>> joinListener(int roomId) async {
+    final res = await _dio.post('/live-chat/listener/join', data: {'room_id': roomId});
+    final body = Map<String, dynamic>.from(res.data);
+    if (body['success'] == true) {
+      return {
+        'listenerId': body['listener_id'],
+        'listenerCount': body['listener_count'] ?? 0,
+      };
+    }
+    throw Exception(body['message'] ?? 'Gagal bergabung');
+  }
+
+  Future<int> leaveListener(int listenerId) async {
+    final res = await _dio.post('/live-chat/listener/$listenerId/leave');
+    final body = Map<String, dynamic>.from(res.data);
+    if (body['success'] == true) {
+      return body['listener_count'] is int
+          ? body['listener_count']
+          : int.tryParse(body['listener_count']?.toString() ?? '') ?? 0;
+    }
+    throw Exception(body['message'] ?? 'Gagal keluar');
+  }
+}

--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:pusher_channels_flutter/pusher_channels_flutter.dart';
+
+import '../config/api_client.dart';
+import '../config/pusher_config.dart';
+import '../models/live_chat_message.dart';
+
+class LiveChatSocketService {
+  LiveChatSocketService._();
+  static final LiveChatSocketService I = LiveChatSocketService._();
+
+  final PusherChannelsFlutter _pusher = PusherChannelsFlutter.getInstance();
+  bool _connected = false;
+
+  Future<void> connect() async {
+    if (_connected) return;
+    ApiClient.I.ensureInterceptors();
+    await _pusher.init(
+      apiKey: PusherConfig.appKey,
+      cluster: PusherConfig.cluster,
+      useTLS: true,
+      onAuthorizer: (channelName, socketId, options) async {
+        final res = await ApiClient.I.dio.post(
+          PusherConfig.authEndpoint,
+          data: {
+            'channel_name': channelName,
+            'socket_id': socketId,
+          },
+        );
+        return res.data;
+      },
+    );
+    await _pusher.connect();
+    _connected = true;
+  }
+
+  Future<void> disconnect() async {
+    if (!_connected) return;
+    await _pusher.disconnect();
+    _connected = false;
+  }
+
+  Future<void> subscribePresence({
+    required int roomId,
+    required void Function(List<dynamic> users) onHere,
+    required void Function(dynamic user) onJoining,
+    required void Function(dynamic user) onLeaving,
+  }) async {
+    await _pusher.subscribe(
+      channelName: 'presence-chat.room.$roomId',
+      onSubscriptionSucceeded: (data) {
+        if (data is Map &&
+            data['presence'] is Map &&
+            (data['presence']['hash'] is Map)) {
+          final hash = Map<String, dynamic>.from(data['presence']['hash']);
+          onHere(hash.values
+              .map((e) => e is Map<String, dynamic>
+                  ? e
+                  : e is Map
+                      ? Map<String, dynamic>.from(e)
+                      : <String, dynamic>{})
+              .toList());
+        } else {
+          onHere(const []);
+        }
+      },
+      onMemberAdded: (member) => onJoining(member.userInfo ?? {}),
+      onMemberRemoved: (member) => onLeaving(member.userInfo ?? {}),
+    );
+  }
+
+  Future<void> subscribePublic({
+    required int roomId,
+    required void Function(LiveChatMessage message) onMessage,
+    required void Function(Map<String, dynamic> data) onSystem,
+  }) async {
+    await _pusher.subscribe(
+      channelName: 'chat.room.$roomId',
+      onEvent: (event) {
+        Map<String, dynamic> payload;
+        if (event.data is String) {
+          payload = jsonDecode(event.data as String) as Map<String, dynamic>;
+        } else {
+          payload = Map<String, dynamic>.from(event.data ?? {});
+        }
+        if (event.eventName == 'message.sent') {
+          final map = payload['message'] is Map
+              ? Map<String, dynamic>.from(payload['message'])
+              : payload;
+          onMessage(LiveChatMessage.fromJson(map));
+        } else {
+          onSystem(payload);
+        }
+      },
+    );
+  }
+
+  Future<void> subscribeLike({
+    required int roomId,
+    required void Function(int likeCount) onUpdated,
+  }) async {
+    await _pusher.subscribe(
+      channelName: 'like-room-$roomId',
+      onEvent: (event) {
+        Map<String, dynamic> payload;
+        if (event.data is String) {
+          payload = jsonDecode(event.data as String) as Map<String, dynamic>;
+        } else {
+          payload = Map<String, dynamic>.from(event.data ?? {});
+        }
+        if (event.eventName == 'LikeUpdated') {
+          final count = payload['likeCount'] is int
+              ? payload['likeCount']
+              : int.tryParse(payload['likeCount']?.toString() ?? '') ?? 0;
+          onUpdated(count);
+        }
+      },
+    );
+  }
+
+  Future<void> subscribeStatus({
+    required void Function(int roomId, String status) onUpdated,
+  }) async {
+    await _pusher.subscribe(
+      channelName: 'live-room-status',
+      onEvent: (event) {
+        if (event.eventName == 'LiveRoomStatusUpdated') {
+          Map<String, dynamic> payload;
+          if (event.data is String) {
+            payload = jsonDecode(event.data as String) as Map<String, dynamic>;
+          } else {
+            payload = Map<String, dynamic>.from(event.data ?? {});
+          }
+          final id = payload['liveRoomId'] is int
+              ? payload['liveRoomId']
+              : int.tryParse(payload['liveRoomId']?.toString() ?? '') ?? 0;
+          final status = payload['status']?.toString() ?? '';
+          onUpdated(id, status);
+        }
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   url_launcher: ^6.2.5
   shared_preferences: ^2.2.2
   web_socket_channel: ^2.4.0
+  pusher_channels_flutter: ^2.1.0
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add pusher_channels_flutter dependency
- implement LiveChatService and socket service for REST and Pusher channels
- refactor LiveChatScreen to use backend and real-time updates
- fix presence channel parsing to handle user info correctly

## Testing
- `dart format lib/services/live_chat_socket_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38fd96554832b823f4caceb28b7e0