### PR TITLE
Initialize LiveChatProvider with init and add shutdown on dispose

### DIFF
--- a/lib/screens/chat/live_chat_screen.dart
+++ b/lib/screens/chat/live_chat_screen.dart
@@ -164,7 +164,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => LiveChatProvider(roomId: widget.roomId),
+      create: (_) => LiveChatProvider(roomId: widget.roomId)..init(),
       child: Consumer<LiveChatProvider>(
         builder: (context, prov, _) {
           if (prov.isLoading) {
@@ -292,6 +292,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
     _scrollController.removeListener(_handleScroll);
     _scrollController.dispose();
     _scrollTimer?.cancel();
+    context.read<LiveChatProvider>().shutdown();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- initialize LiveChatProvider when building LiveChatScreen
- clean up LiveChatProvider connection in dispose

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b3f1ce6110832b868fb0b402620bb2