### PR TITLE
Fix LiveChatProvider scope for live chat screen

### DIFF
--- a/lib/navigation/bottom_nav.dart
+++ b/lib/navigation/bottom_nav.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/live_chat_provider.dart';
 import '../screens/home/home_screen.dart';
 import '../screens/artikel/artikel_screen.dart';
 import '../screens/galeri/galeri_screen.dart';
@@ -86,7 +89,12 @@ class _BottomNavState extends State<BottomNav> {
             if (index == 3) {
               final result = await Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => LiveChatScreen(roomId: 1)), // Ganti dengan ID room yang sesuai
+                MaterialPageRoute(
+                  builder: (_) => ChangeNotifierProvider(
+                    create: (_) => LiveChatProvider(roomId: 1)..init(),
+                    child: const LiveChatScreen(roomId: 1),
+                  ),
+                ),
               );
 
               if (result == 'goHome') {

--- a/lib/screens/chat/live_chat_screen.dart
+++ b/lib/screens/chat/live_chat_screen.dart
@@ -163,10 +163,8 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => LiveChatProvider(roomId: widget.roomId)..init(),
-      child: Consumer<LiveChatProvider>(
-        builder: (context, prov, _) {
+    return Consumer<LiveChatProvider>(
+      builder: (context, prov, _) {
           if (prov.isLoading) {
             return Scaffold(
               appBar: AppBar(title: const Text('Live Chat')),
@@ -282,8 +280,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
               ],
             ),
           );
-        },
-      ),
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- provide LiveChatProvider when navigating to LiveChatScreen
- simplify LiveChatScreen to consume existing provider instead of creating its own

## Testing
- ⚠️ `flutter test` (command not found)
- ⚠️ `dart test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b3f3b70264832b8a97d45f07bb1b10