### PR TITLE
fix: handle numeric parsing in live chat message

### DIFF
--- a/lib/models/live_message_model.dart
+++ b/lib/models/live_message_model.dart
@@ -27,13 +27,24 @@ class LiveChatMessage {
       }
     }
 
+    int _parseId(dynamic value) {
+      if (value == null) return 0;
+      if (value is num) return value.toInt();
+      if (value is String) {
+        return int.tryParse(value) ?? double.tryParse(value)?.toInt() ?? 0;
+      }
+      return 0;
+    }
+
     return LiveChatMessage(
-      id: (json['id'] as num).toInt(),
+      id: _parseId(json['id']),
       message: json['message']?.toString() ?? '',
-      userId: (json['user_id'] as num).toInt(),
+      userId: _parseId(json['user_id']),
       name: json['name']?.toString() ?? '',
       avatar: avatar,
-      timestamp: DateTime.parse(json['timestamp'] as String),
+      timestamp: DateTime.parse(
+        json['timestamp']?.toString() ?? DateTime.now().toIso8601String(),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- handle numeric and string values for message and user IDs in `LiveChatMessage`
- safeguard timestamp parsing when field is missing or non-string

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b40b30697c832b945e1cb72272b316