### PR TITLE
fix: handle csrf token for live chat

### DIFF
--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -886,12 +886,13 @@ class LiveChatSocketService {
   ) async {
     try {
       _log('🔄 Sending message via HTTP to room $roomId');
+      ApiClient.I.ensureInterceptors();
 
       final response = await ApiClient.I.dioRoot.post(
         '/live-chat/$roomId/send',
         data: {'message': message},
         options: Options(
-          headers: const {
+          headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
           },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,8 @@ dependencies:
   share_plus: ^11.0.0
   image_picker: ^1.1.2
   dio: ^5.5.0
+  cookie_jar: ^4.0.6
+  dio_cookie_manager: ^2.1.3
   flutter_secure_storage: ^9.2.2
   intl: ^0.19.0
   google_sign_in: ^6.1.4


### PR DESCRIPTION
## Summary
- add cookie jar and CSRF interceptors to ApiClient
- ensure live chat HTTP fallback uses interceptors with modifiable headers
- include cookie_jar and dio_cookie_manager packages

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4166c91a8832ba62027a924a6f90f