### PR TITLE
Align live chat send endpoint with backend

### DIFF
--- a/lib/services/live_chat_service.dart
+++ b/lib/services/live_chat_service.dart
@@ -96,7 +96,10 @@ class LiveChatService {
 
   Future<LiveChatMessage> sendMessage(int id, String text) async {
     ApiClient.I.ensureInterceptors();
-    final res = await _dio.post('/live-chat/$id/send', data: {'message': text});
+    final res = await _dio.post(
+      '/admin/live-chat/$id/send',
+      data: {'message': text},
+    );
     final body = Map<String, dynamic>.from(res.data);
     return LiveChatMessage.fromJson(
       Map<String, dynamic>.from(body['data'] ?? {}),


### PR DESCRIPTION
## Summary
- ensure LiveChatService posts messages to `/admin/live-chat/{id}/send`
- verified existing socket service and provider use the same admin endpoint for sending messages

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b41e2525e8832bb31b1121b56e14bc