### PR TITLE
refactor: rely on interceptor for csrf

### DIFF
--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -911,10 +911,6 @@ class LiveChatSocketService {
       _log('📤 Sending request to /admin/live-chat/$roomId/send');
       _log('📝 Request data: $requestData');
       
-      // Get CSRF token
-      _log('🔄 Ensuring CSRF token...');
-      await _ensureCsrfToken();
-      
       // Log the headers we're about to send
       final headers = {
         'Accept': 'application/json',
@@ -1020,18 +1016,4 @@ class LiveChatSocketService {
     }
   }
 
-  // Ensure CSRF token is set
-  Future<void> _ensureCsrfToken() async {
-    try {
-      await ApiClient.I.dioRoot.get(
-        '/sanctum/csrf-cookie',
-        options: Options(
-          headers: {'Accept': 'application/json'},
-          validateStatus: (status) => status! < 400,
-        ),
-      );
-    } catch (e) {
-      _log('❌ Error ensuring CSRF token: $e');
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- drop manual CSRF fetch in live chat socket service
- rely on ApiClient interceptor so messages don't trigger `/sanctum/csrf-cookie`

## Testing
- `flutter format lib/services/live_chat_socket_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e35ebd0832b8b4eb026f9a0e6e7