### PR TITLE
Use token-enabled live chat send route

### DIFF
--- a/lib/services/live_chat_service.dart
+++ b/lib/services/live_chat_service.dart
@@ -96,8 +96,8 @@ class LiveChatService {
 
   Future<LiveChatMessage> sendMessage(int id, String text) async {
     ApiClient.I.ensureInterceptors();
-    final res = await _dio.post(
-      '/admin/live-chat/$id/send',
+    final res = await ApiClient.I.dio.post(
+      '/live-chat/$id/send',
       data: {'message': text},
     );
     final body = Map<String, dynamic>.from(res.data);

--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -910,7 +910,7 @@ class LiveChatSocketService {
         'avatar': currentUser['avatar'],
       };
       
-      _log('📤 Sending request to /admin/live-chat/$roomId/send');
+      _log('📤 Sending request to /live-chat/$roomId/send');
       _log('📝 Request data: $requestData');
       
       // Log the headers we're about to send
@@ -924,8 +924,8 @@ class LiveChatSocketService {
       
       // Make the HTTP request with proper headers
       _log('🚀 Sending POST request...');
-      final response = await ApiClient.I.dioRoot.post(
-        '/admin/live-chat/$roomId/send',
+      final response = await ApiClient.I.dio.post(
+        '/live-chat/$roomId/send',
         data: requestData,
         options: Options(
           headers: headers,


### PR DESCRIPTION
## Summary
- Direct live chat HTTP send requests to `/live-chat/{id}/send` so Bearer tokens are accepted
- Align LiveChatService.sendMessage and socket fallback with the same API route

## Testing
- `dart format lib/services/live_chat_service.dart lib/services/live_chat_socket_service.dart` *(fails: command not found)*
- `apt-get install dart -y` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4205d0550832bbb70d62a5dd0a2bc