### PR TITLE
Handle unauthorized in live chat messages

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -287,11 +287,13 @@ class LiveChatProvider with ChangeNotifier {
           // Remove the optimistic message if sending failed
           _messages.removeWhere((m) => m.id == tempId);
           notifyListeners();
-          
+
           // Show error to user (you might want to use a snackbar or toast)
           debugPrint('Failed to send message: $error');
         },
       );
+    } on UnauthorizedException {
+      rethrow;
     } catch (e) {
       // Remove the optimistic message if an exception occurs
       _messages.removeWhere((m) => m.id == tempId);

--- a/lib/screens/chat/live_chat_screen.dart
+++ b/lib/screens/chat/live_chat_screen.dart
@@ -8,6 +8,8 @@ import '../../widgets/chat/chat_message_item.dart';
 import '../../widgets/chat/message_input_field.dart';
 import '../../widgets/chat/unread_messages_label.dart';
 import '../../widgets/chat/no_live_placeholder.dart';
+import '../../services/live_chat_socket_service.dart' show UnauthorizedException;
+import '../../config/app_routes.dart';
 
 class LiveChatScreen extends StatefulWidget {
   final int roomId;
@@ -113,6 +115,10 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
       await prov.send(text);
       _messageController.clear();
       _scrollToBottom();
+    } on UnauthorizedException {
+      if (!mounted) return;
+      Navigator.of(context)
+          .pushNamedAndRemoveUntil(AppRoutes.login, (route) => false);
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- Add `UnauthorizedException` and token validation before sending chat messages.
- Clear tokens and surface re-authentication when server responds 401/403.
- Propagate unauthorized errors so UI can redirect to login.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4205b6210832b8a115341054bf880