### PR TITLE
Prevent duplicate live chat messages and track user

### DIFF
--- a/lib/screens/chat/live_chat_screen.dart
+++ b/lib/screens/chat/live_chat_screen.dart
@@ -37,6 +37,10 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
   void initState() {
     super.initState();
     _scrollController.addListener(_handleScroll);
+    final userId = context.read<UserProvider>().user?.id;
+    if (userId != null) {
+      context.read<LiveChatProvider>().setCurrentUserId(userId);
+    }
   }
 
   void _handleScroll() {


### PR DESCRIPTION
## Summary
- avoid duplicating sent messages when server echoes them back
- set current user ID on chat screen to ignore self socket events

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4424cb5d8832b9a95093c8415cd5e