### PR TITLE
Use UserProvider name for live chat send

### DIFF
--- a/lib/screens/chat/live_chat_screen.dart
+++ b/lib/screens/chat/live_chat_screen.dart
@@ -96,9 +96,10 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
   Future<void> _sendMessage(LiveChatProvider prov) async {
     final text = _messageController.text.trim();
     if (text.isEmpty) return;
+    final userName = context.read<UserProvider>().user?.name ?? 'Anda';
 
     try {
-      await prov.send(text);
+      await prov.send(text, username: userName);
       _messageController.clear();
       _scrollToBottom();
     } catch (e) {


### PR DESCRIPTION
## Summary
- pass current user's name to `LiveChatProvider.send` so optimistic messages render as user

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b444aefa58832b8ff28e428602d361