### PR TITLE
Await message send callback in chat input

### DIFF
--- a/lib/screens/chat/chat/message_input_field.dart
+++ b/lib/screens/chat/chat/message_input_field.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class MessageInputField extends StatefulWidget {
   final TextEditingController controller;
-  final VoidCallback onSend;
+  final Future<void> Function() onSend;
 
   const MessageInputField({
     super.key,
@@ -56,8 +56,8 @@ class _MessageInputFieldState extends State<MessageInputField> {
                 maxLines: null,
                 minLines: 1,
                 textInputAction: TextInputAction.send,
-                onSubmitted: (_) {
-                  if (_hasText) widget.onSend();
+                onSubmitted: (_) async {
+                  if (_hasText) await widget.onSend();
                 },
                 decoration: InputDecoration(
                   hintText: 'Ketik pesan...',
@@ -91,7 +91,11 @@ class _MessageInputFieldState extends State<MessageInputField> {
                     : Colors.grey,
                 shape: const CircleBorder(),
               ),
-              onPressed: _hasText ? widget.onSend : null,
+              onPressed: _hasText
+                  ? () async {
+                      await widget.onSend();
+                    }
+                  : null,
             ),
           ],
         ),

--- a/lib/screens/chat/live_chat_screen.dart
+++ b/lib/screens/chat/live_chat_screen.dart
@@ -328,7 +328,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                     right: 0,
                     child: MessageInputField(
                       controller: _messageController,
-                      onSend: () => _sendMessage(prov),
+                      onSend: () async => _sendMessage(prov),
                     ),
                   ),
               ],


### PR DESCRIPTION
## Summary
- make `MessageInputField` accept an async send callback and await it when submitting or pressing send
- update `LiveChatScreen` to pass async send handler

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6afafa140832baa2b45e92f5355cd