### PR TITLE
Handle initial presence members in live chat

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -125,6 +125,26 @@ class LiveChatProvider with ChangeNotifier {
         notifyListeners();
       },
 
+      onInitialMembers: (channel, members) {
+        _onlineUsers
+          ..clear()
+          ..addAll(members.map((user) {
+            final userId = (user['userId'] ?? '').toString();
+            final userInfo = user['userInfo'] is Map
+                ? Map<String, dynamic>.from(user['userInfo'])
+                : <String, dynamic>{};
+            final username = userInfo['name']?.toString() ?? 'Unknown User';
+
+            return OnlineUser(
+              id: userId,
+              username: username,
+              userAvatar: userInfo['avatar']?.toString(),
+              joinTime: DateTime.now(),
+            );
+          }));
+        notifyListeners();
+      },
+
       onUserJoined: (channel, user) {
         final userId = (user['userId'] ?? '').toString();
         final userInfo = user['userInfo'] is Map


### PR DESCRIPTION
## Summary
- parse initial presence data on subscription and notify via `onInitialMembers`
- expose `onInitialMembers` callback and update provider to populate online users

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6afbcbe48832b946723f132577ff4