### PR TITLE
Render chat system messages without bubbles

### DIFF
--- a/lib/screens/chat/chat/system_message_item.dart
+++ b/lib/screens/chat/chat/system_message_item.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class SystemMessageItem extends StatelessWidget {
+  final String message;
+  const SystemMessageItem({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Center(
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodySmall?.copyWith(
+            fontSize: 12,
+            color: Colors.grey[400],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/chat/live_chat_screen.dart
+++ b/lib/screens/chat/live_chat_screen.dart
@@ -8,6 +8,7 @@ import 'chat/chat_message_item.dart';
 import 'chat/message_input_field.dart';
 import 'chat/unread_messages_label.dart';
 import 'chat/no_live_placeholder.dart';
+import 'chat/system_message_item.dart';
 
 class LiveChatScreen extends StatefulWidget {
   final int roomId;
@@ -266,23 +267,32 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                     itemCount: messages.length,
                     itemBuilder: (context, index) {
                       final message = messages[index];
+                      final isSystem =
+                          message.isSystemMessage || message.isJoinNotification;
+
+                      final displayText =
+                          (isSystem && message.username != 'System')
+                              ? '${message.username} ${message.message}'
+                              : message.message;
+
+                      final messageWidget = isSystem
+                          ? SystemMessageItem(message: displayText)
+                          : ChatMessageItem(
+                              message: message,
+                              isCurrentUser:
+                                  _isCurrentUser(message.username),
+                              time: prov.formatTime(message.timestamp),
+                            );
+
                       if (_isUserScrolledUp && index == _firstUnreadIndex) {
                         return Column(
                           children: [
                             UnreadMessagesLabel(count: unreadCount),
-                            ChatMessageItem(
-                              message: message,
-                              isCurrentUser: _isCurrentUser(message.username),
-                              time: prov.formatTime(message.timestamp),
-                            ),
+                            messageWidget,
                           ],
                         );
                       }
-                      return ChatMessageItem(
-                        message: message,
-                        isCurrentUser: _isCurrentUser(message.username),
-                        time: prov.formatTime(message.timestamp),
-                      );
+                      return messageWidget;
                     },
                   ),
 


### PR DESCRIPTION
## Summary
- Add `SystemMessageItem` to show system chat events as small centered text
- Detect system/join notifications in `LiveChatScreen` and render them without bubbles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b4975894832b818af133ef08fd93