### PR TITLE
Ensure presence auth includes user data and CSRF header

### DIFF
--- a/lib/config/api_client.dart
+++ b/lib/config/api_client.dart
@@ -115,6 +115,9 @@ class ApiClient {
           }
           if (token != null) {
             options.headers['X-XSRF-TOKEN'] = token;
+            // Beberapa endpoint (seperti /broadcasting/auth) juga
+            // mengharapkan header X-CSRF-TOKEN secara eksplisit.
+            options.headers['X-CSRF-TOKEN'] = token;
           }
           handler.next(options);
         },

--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -197,8 +197,25 @@ class LiveChatSocketService {
         );
         if ((response.statusCode ?? 0) >= 200 &&
             (response.statusCode ?? 0) < 300) {
-          return response.data ?? {};
+          final data = response.data ?? {};
+          final auth = data['auth'];
+          final channelData = data['channel_data'];
+          if (auth is String && channelData is String) {
+            try {
+              final decoded = jsonDecode(channelData);
+              if (decoded is Map &&
+                  decoded['user_id'] != null &&
+                  decoded['user_info'] != null) {
+                return {'auth': auth, 'channel_data': channelData};
+              }
+            } catch (e) {
+              debugPrint('Invalid channel_data: $e');
+            }
+          }
+          throw Exception('Auth response missing required fields');
         }
+        debugPrint(
+            'Auth failed: status=${response.statusCode} body=${response.data}');
         throw Exception('Auth failed: ${response.statusMessage}');
       }
       return {};


### PR DESCRIPTION
## Summary
- send X-CSRF-TOKEN header when authenticating Pusher channels
- validate Pusher auth response includes user_id and user_info

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b48f1b44832ba12299fc9bbecae2