### PR TITLE
Show emoji join/leave messages for presence events

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -162,39 +162,12 @@ class LiveChatProvider with ChangeNotifier {
             joinTime: DateTime.now(),
           ),
         );
-
-        // notifikasi bergabung (opsional)
-        final joinMessage = ChatMessage(
-          id: 'join-$userId-${DateTime.now().microsecondsSinceEpoch}',
-          username: username,
-          message: 'telah bergabung ke ruang chat',
-          timestamp: DateTime.now(),
-          isJoinNotification: true,
-        );
-        _messages.add(joinMessage);
-
         notifyListeners();
       },
 
       onUserLeft: (channel, user) {
         final userId = (user['userId'] ?? '').toString();
-        final userInfo = user['userInfo'] is Map
-            ? Map<String, dynamic>.from(user['userInfo'])
-            : <String, dynamic>{};
-        final username = userInfo['name']?.toString() ?? 'User';
-
         _onlineUsers.removeWhere((u) => u.id == userId);
-
-        // notifikasi keluar (opsional)
-        final leaveMessage = ChatMessage(
-          id: 'leave-$userId-${DateTime.now().microsecondsSinceEpoch}',
-          username: username,
-          message: 'telah meninggalkan ruang chat',
-          timestamp: DateTime.now(),
-          isSystemMessage: true,
-        );
-        _messages.add(leaveMessage);
-
         notifyListeners();
       },
 

--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -459,7 +459,7 @@ class LiveChatSocketService {
         _onSystem?.call({
           'type': 'system',
           'message':
-              '${processedUser['userInfo']['name']} telah bergabung ke siaran',
+              '🎉 ${processedUser['userInfo']['name']} bergabung',
           'user': processedUser,
           'isSubtle': true,
           'timestamp': DateTime.now().toIso8601String(),
@@ -468,7 +468,7 @@ class LiveChatSocketService {
         _onSystem?.call({
           'type': 'system',
           'message':
-              '${processedUser['userInfo']['name']} telah meninggalkan siaran',
+              '👋 ${processedUser['userInfo']['name']} keluar',
           'user': processedUser,
           'isSubtle': true,
           'timestamp': DateTime.now().toIso8601String(),


### PR DESCRIPTION
## Summary
- call `_handlePresenceEvent` on member join/leave callbacks
- emit emoji-based system messages for user join/leave
- remove duplicate join/leave notifications in provider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b494c8b8832bb9a36fc90cb1d281