### PR TITLE
refactor: handle Firebase token retrieval

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -276,8 +276,11 @@ class AuthService {
       }
 
       // 4) Ambil Firebase ID token
-      final idToken = await fbUser.getIdToken();
-      if (idToken == null) {
+      String idToken;
+      try {
+        idToken = await fbUser.getIdToken();
+      } catch (e, st) {
+        _logger.e('Failed to get Firebase ID token: $e', stackTrace: st);
         await logout();
         return const AuthResult(
           status: false,


### PR DESCRIPTION
## Summary
- remove unused null-check on Firebase ID token in Google login
- wrap Firebase token retrieval in try/catch for clearer error handling

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b1c19dbc832b93cb982f58a4db3d