### PR TITLE
Call logout on Google login failure

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -153,8 +153,10 @@ class AuthProvider with ChangeNotifier {
         return null;
       }
 
+      await AuthService.I.logout();
       return result.message ?? 'Login gagal';
     } catch (e) {
+      await AuthService.I.logout();
       return 'Terjadi kesalahan: $e';
     } finally {
       _loading = false;


### PR DESCRIPTION
## Summary
- Ensure Google login failures trigger logout

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b334cba4832b85a01b5adbed2ca8