### PR TITLE
Attempt silent Google login before interactive

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -242,13 +242,14 @@ class AuthService {
     }
   }
 
-  /// LOGIN WITH GOOGLE → Firebase → tukar idToken dengan token backend
+  /// LOGIN WITH GOOGLE (silent terlebih dahulu) → Firebase → tukar idToken dengan token backend
   Future<AuthResult> loginWithGoogle() async {
     try {
       _logger.i('1) Mulai login Google');
 
-      // 1) Coba silent login dulu
-      final GoogleSignInAccount? googleUser = await _googleSignIn.signIn();
+      // 1) Coba login Google: signInSilently() lebih dulu, fallback ke signIn() jika null
+      GoogleSignInAccount? googleUser = await _googleSignIn.signInSilently();
+      googleUser ??= await _googleSignIn.signIn();
       if (googleUser == null) {
         _logger.w('User membatalkan Google Sign-In');
         return const AuthResult(


### PR DESCRIPTION
## Summary
- Attempt a silent Google sign-in first when logging in
- Fall back to interactive Google sign-in only if no account is cached
- Clarify comments to describe silent then interactive login flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b332a0f4832bbf8fce8c4d7b3291