### PR TITLE
Use named GoogleSignIn constructor

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -38,8 +38,8 @@ class AuthService {
 
   final _storage = const FlutterSecureStorage();
 
-  /// Gunakan konstruktor biasa (API resmi).
-  final GoogleSignIn _googleSignIn = GoogleSignIn(
+  /// Gunakan konstruktor standar dari `GoogleSignIn`.
+  final GoogleSignIn _googleSignIn = GoogleSignIn.standard(
     scopes: <String>['email', 'profile'],
   );
 


### PR DESCRIPTION
## Summary
- Replace GoogleSignIn field initialization with `GoogleSignIn.standard` to avoid unnamed constructor usage

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b50819d0832b8257c4e99cb86f8b