### PR TITLE
Add env file fallback to prevent startup stall

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart'; // ⬅️ Firebase init
 import 'package:just_audio_background/just_audio_background.dart';
@@ -27,7 +29,11 @@ Future<void> main() async {
   await Firebase.initializeApp();
 
   // 2) Load environment variables
-  await dotenv.load(fileName: '.env');
+  if (await File('.env').exists()) {
+    await dotenv.load(fileName: '.env');
+  } else {
+    await dotenv.load(fileName: '.env.example');
+  }
 
   // 3) Setup API client interceptors (auth header, cookies, csrf, dll)
   ApiClient.I.ensureInterceptors();


### PR DESCRIPTION
## Summary
- Prevent startup issues when `.env` is missing by falling back to `.env.example`
- Add `dart:io` import for file existence check

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d1087970832b80e7cd20b3ca51c4