### PR TITLE
chore: add google services plugin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+    id("com.google.gms.google-services")
 }
 
 android {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,3 +1,9 @@
+buildscript {
+    dependencies {
+        classpath("com.google.gms:google-services:4.4.2")
+    }
+}
+
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
## Summary
- include Google services classpath in root Gradle build
- apply Google services plugin to app module

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d5014210832b94262ee7b333830a