### PR TITLE
Add Facebook SDK initialization for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:label="radio_odan_app"
-        android:name="${applicationName}"
+        android:name=".MainApplication"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
@@ -30,6 +30,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data android:name="com.facebook.sdk.ApplicationId"
+               android:value="@string/facebook_app_id" />
+        <meta-data android:name="com.facebook.sdk.ClientToken"
+               android:value="@string/facebook_client_token" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/example/radio_odan_app/MainApplication.kt
+++ b/android/app/src/main/kotlin/com/example/radio_odan_app/MainApplication.kt
@@ -1,0 +1,11 @@
+package com.example.radio_odan_app
+
+import io.flutter.app.FlutterApplication
+import com.facebook.FacebookSdk
+
+class MainApplication : FlutterApplication() {
+    override fun onCreate() {
+        super.onCreate()
+        FacebookSdk.sdkInitialize(applicationContext)
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="facebook_app_id">YOUR_APP_ID</string>
+    <string name="facebook_client_token">YOUR_CLIENT_TOKEN</string>
+</resources>


### PR DESCRIPTION
## Summary
- Initialize Facebook SDK in custom `MainApplication`
- Register application ID and client token in Android manifest
- Provide placeholder string resources for Facebook credentials

## Testing
- `gradle assembleDebug` *(fails: `/workspace/radio_app/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d51cce3c832ba3191006b63613b9