### PR TITLE
refactor: use theme colors in screens

### DIFF
--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -15,6 +15,9 @@ class AppColors {
   // Text Colors
   static const Color textPrimary = Colors.white;
   static const Color textSecondary = Color(0xFFB3B3B3);
+
+  // Semantic Colors
+  static const Color error = Color(0xFFB00020);
   
   // Gradients
   static const LinearGradient darkGradient = LinearGradient(

--- a/lib/config/app_theme.dart
+++ b/lib/config/app_theme.dart
@@ -6,12 +6,24 @@ class AppTheme {
     brightness: Brightness.light,
     primaryColor: AppColors.primary,
     scaffoldBackgroundColor: AppColors.backgroundLight,
+    colorScheme: const ColorScheme.light(
+      primary: AppColors.primary,
+      secondary: AppColors.primary,
+      surface: AppColors.surfaceLight,
+      background: AppColors.backgroundLight,
+      error: AppColors.error,
+      onPrimary: Colors.white,
+      onSecondary: Colors.white,
+      onSurface: Colors.black,
+      onBackground: Colors.black,
+      onError: Colors.white,
+    ),
     appBarTheme: const AppBarTheme(
       backgroundColor: AppColors.backgroundLight,
-      foregroundColor: AppColors.textPrimary,
+      foregroundColor: Colors.black,
       elevation: 0,
       titleTextStyle: TextStyle(
-        color: AppColors.textPrimary,
+        color: Colors.black,
         fontSize: 20,
         fontWeight: FontWeight.bold,
       ),
@@ -19,12 +31,27 @@ class AppTheme {
     bottomNavigationBarTheme: const BottomNavigationBarThemeData(
       backgroundColor: AppColors.backgroundLight,
       selectedItemColor: AppColors.primary,
-      unselectedItemColor: Colors.grey,
+      unselectedItemColor: AppColors.textSecondary,
     ),
     cardTheme: const CardThemeData(
       elevation: 2,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.all(Radius.circular(12)),
+      ),
+    ),
+    textTheme: const TextTheme(
+      titleLarge: TextStyle(
+        color: Colors.black,
+        fontWeight: FontWeight.bold,
+        fontSize: 24,
+      ),
+      bodyLarge: TextStyle(
+        color: Colors.black,
+        fontSize: 16,
+      ),
+      bodyMedium: TextStyle(
+        color: Colors.black54,
+        fontSize: 14,
       ),
     ),
   );
@@ -38,6 +65,12 @@ class AppTheme {
       secondary: AppColors.primary,
       surface: AppColors.surface,
       background: AppColors.backgroundDark, // Keeping for backward compatibility
+      error: AppColors.error,
+      onPrimary: AppColors.textPrimary,
+      onSecondary: AppColors.textPrimary,
+      onSurface: AppColors.textPrimary,
+      onBackground: AppColors.textPrimary,
+      onError: AppColors.textPrimary,
     ),
     appBarTheme: AppBarTheme(
       backgroundColor: AppColors.backgroundDark,

--- a/lib/screens/common/not_found_screen.dart
+++ b/lib/screens/common/not_found_screen.dart
@@ -13,7 +13,12 @@ class NotFoundScreen extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.search_off, size: 100, color: Colors.grey),
+              Icon(
+                Icons.search_off,
+                size: 100,
+                color:
+                    Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+              ),
               const SizedBox(height: 24),
               const Text(
                 'Halaman Tidak Ditemukan',
@@ -21,9 +26,14 @@ class NotFoundScreen extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 12),
-              const Text(
+              Text(
                 'Maaf, halaman yang kamu tuju tidak tersedia atau argumennya tidak valid.',
-                style: TextStyle(fontSize: 16, color: Colors.black54),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onBackground
+                          .withOpacity(0.6),
+                    ),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 32),

--- a/lib/screens/event/all_events_screen.dart
+++ b/lib/screens/event/all_events_screen.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 
-import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/models/event_model.dart';
 import 'package:radio_odan_app/providers/event_provider.dart';
 import 'package:radio_odan_app/widgets/app_bar.dart';
@@ -102,22 +101,31 @@ class _AllEventsScreenState extends State<AllEventsScreen>
     return Scaffold(
       key: const Key('all_events_screen'),
       appBar: CustomAppBar.transparent(title: 'Semua Event'),
-      backgroundColor: AppColors.backgroundDark,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: Stack(
         children: [
           Positioned.fill(
             child: Container(
-              decoration: const BoxDecoration(
+              decoration: BoxDecoration(
                 gradient: LinearGradient(
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
-                  colors: [AppColors.primary, AppColors.backgroundDark],
+                  colors: [
+                    Theme.of(context).colorScheme.primary,
+                    Theme.of(context).colorScheme.background,
+                  ],
                 ),
               ),
               child: Stack(
                 children: [
-                  Positioned(top: 50, right: -50, child: _bubble(200, 0.05)),
-                  Positioned(bottom: -50, left: -50, child: _bubble(250, 0.03)),
+                  Positioned(
+                      top: 50,
+                      right: -50,
+                      child: _bubble(context, 200, 0.05)),
+                  Positioned(
+                      bottom: -50,
+                      left: -50,
+                      child: _bubble(context, 250, 0.03)),
                 ],
               ),
             ),
@@ -143,12 +151,18 @@ class _AllEventsScreenState extends State<AllEventsScreen>
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const Icon(Icons.error_outline, color: Colors.red, size: 48),
+                  Icon(Icons.error_outline,
+                      color: Theme.of(context).colorScheme.error, size: 48),
                   const SizedBox(height: 12),
                   Text(
                     'Gagal memuat event:\n${provider.error}',
                     textAlign: TextAlign.center,
-                    style: const TextStyle(color: Colors.white70),
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onBackground
+                              .withOpacity(0.7),
+                        ),
                   ),
                   const SizedBox(height: 12),
                   ElevatedButton(
@@ -162,10 +176,15 @@ class _AllEventsScreenState extends State<AllEventsScreen>
         }
 
         if (provider.events.isEmpty) {
-          return const Center(
+          return Center(
             child: Text(
               'Tidak ada event yang tersedia',
-              style: TextStyle(color: Colors.white70),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onBackground
+                        .withOpacity(0.7),
+                  ),
             ),
           );
         }
@@ -210,7 +229,7 @@ class _AllEventsScreenState extends State<AllEventsScreen>
     return Card(
       key: Key('event_${e.id}'),
       margin: const EdgeInsets.only(bottom: 16),
-      color: AppColors.surface.withOpacity(0.9),
+      color: Theme.of(context).colorScheme.surface.withOpacity(0.9),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       elevation: 2,
       child: InkWell(
@@ -230,22 +249,23 @@ class _AllEventsScreenState extends State<AllEventsScreen>
                   width: double.infinity,
                   height: 180,
                   child: url.isEmpty
-                      ? _thumbPlaceholder()
+                      ? _thumbPlaceholder(context)
                       : CachedNetworkImage(
                           imageUrl: url,
                           fit: BoxFit.cover,
                           placeholder: (_, __) => _thumbLoading(),
-                          errorWidget: (_, __, ___) => _thumbPlaceholder(),
+                          errorWidget: (_, __, ___) =>
+                              _thumbPlaceholder(context),
                         ),
                 ),
               ),
               const SizedBox(height: 12),
               Text(
                 e.judul,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
-                  color: Colors.white,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
@@ -255,7 +275,10 @@ class _AllEventsScreenState extends State<AllEventsScreen>
                 e.formattedTanggal,
                 style: TextStyle(
                   fontSize: 14,
-                  color: Colors.white.withOpacity(0.8),
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withOpacity(0.8),
                 ),
               ),
             ],
@@ -265,15 +288,19 @@ class _AllEventsScreenState extends State<AllEventsScreen>
     );
   }
 
-  Widget _thumbPlaceholder() => Container(
-    color: Colors.grey[900],
-    alignment: Alignment.center,
-    child: const Icon(
-      Icons.image_not_supported,
-      size: 40,
-      color: Colors.white38,
-    ),
-  );
+  Widget _thumbPlaceholder(BuildContext context) => Container(
+        color:
+            Theme.of(context).colorScheme.onSurface.withOpacity(0.9),
+        alignment: Alignment.center,
+        child: Icon(
+          Icons.image_not_supported,
+          size: 40,
+          color: Theme.of(context)
+              .colorScheme
+              .onSurface
+              .withOpacity(0.38),
+        ),
+      );
 
   Widget _thumbLoading() => const Center(
     child: SizedBox(
@@ -283,12 +310,16 @@ class _AllEventsScreenState extends State<AllEventsScreen>
     ),
   );
 
-  Widget _bubble(double size, double opacity) => Container(
-    width: size,
-    height: size,
-    decoration: BoxDecoration(
-      shape: BoxShape.circle,
-      color: Colors.white.withOpacity(opacity),
-    ),
-  );
+  Widget _bubble(BuildContext context, double size, double opacity) =>
+      Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: Theme.of(context)
+              .colorScheme
+              .onPrimary
+              .withOpacity(opacity),
+        ),
+      );
 }


### PR DESCRIPTION
## Summary
- add semantic error color and expand color schemes in app theme
- refactor not found and events screens to use Theme color scheme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e19557d0832b856f423f2e710881