### PR TITLE
refactor: use theme color scheme

### DIFF
--- a/lib/config/app_theme.dart
+++ b/lib/config/app_theme.dart
@@ -3,8 +3,18 @@ import 'app_colors.dart';
 
 class AppTheme {
   static ThemeData lightTheme = ThemeData(
-    brightness: Brightness.light,
-    primaryColor: AppColors.primary,
+    colorScheme: const ColorScheme.light(
+      primary: AppColors.primary,
+      secondary: AppColors.primary,
+      background: AppColors.backgroundLight,
+      surface: Colors.white,
+      error: Colors.red,
+      onPrimary: Colors.white,
+      onSecondary: Colors.white,
+      onBackground: AppColors.textPrimary,
+      onSurface: AppColors.textPrimary,
+      onError: Colors.white,
+    ),
     scaffoldBackgroundColor: AppColors.backgroundLight,
     appBarTheme: const AppBarTheme(
       backgroundColor: AppColors.backgroundLight,
@@ -31,13 +41,18 @@ class AppTheme {
 
   static ThemeData darkTheme = ThemeData(
     brightness: Brightness.dark,
-    primaryColor: AppColors.primary,
     scaffoldBackgroundColor: AppColors.backgroundDark,
     colorScheme: const ColorScheme.dark(
       primary: AppColors.primary,
       secondary: AppColors.primary,
+      background: AppColors.backgroundDark,
       surface: AppColors.surface,
-      background: AppColors.backgroundDark, // Keeping for backward compatibility
+      error: Colors.red,
+      onPrimary: Colors.white,
+      onSecondary: Colors.white,
+      onBackground: AppColors.textPrimary,
+      onSurface: AppColors.textPrimary,
+      onError: Colors.white,
     ),
     appBarTheme: AppBarTheme(
       backgroundColor: AppColors.backgroundDark,

--- a/lib/screens/artikel/artikel_detail_screen.dart
+++ b/lib/screens/artikel/artikel_detail_screen.dart
@@ -4,7 +4,6 @@ import 'package:html/dom.dart' as dom;
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/widgets/app_bar.dart';
 import 'package:radio_odan_app/widgets/loading/loading_widget.dart';
@@ -44,20 +43,21 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
   Widget build(BuildContext context) {
     return Consumer<ArtikelProvider>(
       builder: (context, provider, _) {
+        final colors = Theme.of(context).colorScheme;
         final artikel = provider.selectedArtikel;
         final error = provider.error;
         final isLoading = provider.isLoadingDetail;
 
         if (isLoading) {
-          return const Scaffold(
-            backgroundColor: AppColors.backgroundDark,
-            body: Center(child: LoadingWidget()),
+          return Scaffold(
+            backgroundColor: colors.background,
+            body: const Center(child: LoadingWidget()),
           );
         }
 
         if (error != null || artikel == null) {
           return Scaffold(
-            backgroundColor: AppColors.backgroundDark,
+            backgroundColor: colors.background,
             appBar: CustomAppBar.transparent(title: 'Error'),
             body: Center(
               child: Column(
@@ -84,22 +84,22 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
             content.isEmpty || content == '<p></p>' || content == '<div></div>';
 
         return Scaffold(
-          backgroundColor: AppColors.backgroundDark,
+          backgroundColor: colors.background,
           appBar: CustomAppBar.transparent(title: artikel.title),
           body: RefreshIndicator(
             onRefresh: _loadArticle,
-            color: AppColors.primary,
-            backgroundColor: AppColors.backgroundDark,
+            color: colors.primary,
+            backgroundColor: colors.background,
             child: Stack(
               children: [
                 // Background
                 Positioned.fill(
                   child: Container(
-                    decoration: const BoxDecoration(
+                    decoration: BoxDecoration(
                       gradient: LinearGradient(
                         begin: Alignment.topCenter,
                         end: Alignment.bottomCenter,
-                        colors: [AppColors.primary, AppColors.backgroundDark],
+                        colors: [colors.primary, colors.background],
                       ),
                     ),
                     child: Stack(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 // Config
-import 'package:radio_odan_app/config/app_colors.dart';
 
 // Providers
 import '../../providers/program_provider.dart';
@@ -123,9 +122,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return Scaffold(
       key: _scaffoldKey,
-      backgroundColor: AppColors.backgroundDark,
+      backgroundColor: colors.background,
       drawer: const AppDrawer(),
       body: LayoutBuilder(
         builder: (context, constraints) {
@@ -138,7 +139,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                     gradient: LinearGradient(
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,
-                      colors: [AppColors.primary, AppColors.backgroundDark],
+                      colors: [colors.primary, colors.background],
                     ),
                   ),
                   child: Stack(
@@ -188,8 +189,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 child: RefreshIndicator(
                   key: _refreshIndicatorKey,
                   onRefresh: _refreshAll,
-                  color: AppColors.primary,
-                  backgroundColor: AppColors.backgroundDark,
+                  color: colors.primary,
+                  backgroundColor: colors.background,
                   child: CustomScrollView(
                     key: const Key('home_scroll_view'),
                     physics: const AlwaysScrollableScrollPhysics(

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
@@ -61,14 +60,19 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       iconColor: iconColor,
       actions: actions,
       leading: leading,
-      flexibleSpace: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [Colors.transparent, AppColors.primary],
-          ),
-        ),
+      flexibleSpace: Builder(
+        builder: (context) {
+          final colors = Theme.of(context).colorScheme;
+          return Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [Colors.transparent, colors.primary],
+              ),
+            ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- expose ColorScheme in AppTheme for light and dark themes
- read colors from Theme instead of AppColors in Home and ArtikelDetail screens
- derive app bar gradient from theme

## Testing
- `dart format lib/config/app_theme.dart lib/screens/home/home_screen.dart lib/screens/artikel/artikel_detail_screen.dart lib/widgets/app_bar.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e19fc234832bb111da6f6f35b4e6