### PR TITLE
refactor: use theme text styles

### DIFF
--- a/lib/config/app_theme.dart
+++ b/lib/config/app_theme.dart
@@ -27,6 +27,30 @@ class AppTheme {
         borderRadius: BorderRadius.all(Radius.circular(12)),
       ),
     ),
+    textTheme: const TextTheme(
+      titleLarge: TextStyle(
+        color: Colors.black87,
+        fontWeight: FontWeight.bold,
+        fontSize: 24,
+      ),
+      titleMedium: TextStyle(
+        color: Colors.black87,
+        fontWeight: FontWeight.w600,
+        fontSize: 20,
+      ),
+      bodyLarge: TextStyle(
+        color: Colors.black87,
+        fontSize: 16,
+      ),
+      bodyMedium: TextStyle(
+        color: Colors.black54,
+        fontSize: 14,
+      ),
+      bodySmall: TextStyle(
+        color: Colors.black45,
+        fontSize: 12,
+      ),
+    ),
   );
 
   static ThemeData darkTheme = ThemeData(
@@ -68,6 +92,11 @@ class AppTheme {
         fontWeight: FontWeight.bold,
         fontSize: 24,
       ),
+      titleMedium: TextStyle(
+        color: AppColors.textPrimary,
+        fontWeight: FontWeight.w600,
+        fontSize: 20,
+      ),
       bodyLarge: TextStyle(
         color: AppColors.textPrimary,
         fontSize: 16,
@@ -75,6 +104,10 @@ class AppTheme {
       bodyMedium: TextStyle(
         color: AppColors.textSecondary,
         fontSize: 14,
+      ),
+      bodySmall: TextStyle(
+        color: AppColors.textSecondary,
+        fontSize: 12,
       ),
     ),
   );

--- a/lib/screens/common/not_found_screen.dart
+++ b/lib/screens/common/not_found_screen.dart
@@ -5,6 +5,7 @@ class NotFoundScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(title: const Text('404'), centerTitle: true),
       body: Center(
@@ -13,17 +14,23 @@ class NotFoundScreen extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.search_off, size: 100, color: Colors.grey),
+              Icon(
+                Icons.search_off,
+                size: 100,
+                color: theme.colorScheme.onBackground.withOpacity(0.5),
+              ),
               const SizedBox(height: 24),
-              const Text(
+              Text(
                 'Halaman Tidak Ditemukan',
-                style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+                style: theme.textTheme.titleLarge?.copyWith(fontSize: 22),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 12),
-              const Text(
+              Text(
                 'Maaf, halaman yang kamu tuju tidak tersedia atau argumennya tidak valid.',
-                style: TextStyle(fontSize: 16, color: Colors.black54),
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onBackground.withOpacity(0.54),
+                ),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 32),

--- a/lib/screens/home/widgets/program_list.dart
+++ b/lib/screens/home/widgets/program_list.dart
@@ -88,11 +88,16 @@ class _ProgramListState extends State<ProgramList>
             title: 'Program Hari Ini',
             onSeeAll: () => _openAll(context),
           ),
-          const Padding(
-            padding: EdgeInsets.all(16.0),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
             child: Text(
               'Tidak ada program untuk hari ini',
-              style: TextStyle(color: Colors.white70),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onBackground
+                        .withOpacity(0.7),
+                  ),
             ),
           ),
         ],
@@ -162,11 +167,9 @@ class _ProgramListState extends State<ProgramList>
                           program.namaProgram,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w700,
-                            color: Colors.white,
-                          ),
+                          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                fontWeight: FontWeight.w700,
+                              ),
                         ),
                       ],
                     ),

--- a/lib/widgets/section_title.dart
+++ b/lib/widgets/section_title.dart
@@ -14,6 +14,7 @@ class SectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
@@ -23,21 +24,15 @@ class SectionTitle extends StatelessWidget {
             title,
             style:
                 titleStyle ??
-                const TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
-                  letterSpacing: 0.5,
-                ),
+                theme.textTheme.titleMedium?.copyWith(letterSpacing: 0.5),
           ),
           if (onSeeAll != null)
             GestureDetector(
               onTap: onSeeAll,
               child: Text(
                 "Lihat Semua",
-                style: TextStyle(
-                  fontSize: 14,
-                  color: Colors.amber[300],
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.secondary,
                   fontWeight: FontWeight.w500,
                 ),
               ),


### PR DESCRIPTION
## Summary
- define comprehensive text styles in `AppTheme`
- replace ad-hoc `TextStyle` usage with theme text styles

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1ac24d4832ba229a1b6f3bd0760