### PR TITLE
Add event detail screen and navigation

### DIFF
--- a/lib/config/app_routes.dart
+++ b/lib/config/app_routes.dart
@@ -15,10 +15,12 @@ import '../screens/auth/reset_password_screen.dart'; // opsional
 import '../screens/program/all_programs_screen.dart';
 import '../screens/program/program_detail_screen.dart';
 import '../screens/event/all_events_screen.dart';
+import '../screens/event/event_detail_screen.dart';
 
 // Screens (Artikel)
 import '../screens/artikel/artikel_detail_screen.dart';
 import '../models/artikel_model.dart';
+import '../models/event_model.dart';
 
 // Screens (Galeri)
 import '../screens/galeri/all_videos_screen.dart';
@@ -49,6 +51,7 @@ class AppRoutes {
 
   static const String artikelDetail = '/artikel-detail';
   static const String programDetail = '/program-detail';
+  static const String eventDetail = '/event-detail';
   static const String allPrograms = '/program-semua';
   static const String allVideos = '/all-videos';
   static const String albumList = '/album-semua';
@@ -146,6 +149,15 @@ class AppRoutes {
 
       case programDetail:
         return const ProgramDetailScreen();
+
+      case eventDetail:
+        {
+          final arg = settings.arguments;
+          if (arg is Event) {
+            return EventDetailScreen(event: arg);
+          }
+          return const NotFoundScreen();
+        }
 
       case allPrograms:
         return const AllProgramsScreen();

--- a/lib/screens/event/all_events_screen.dart
+++ b/lib/screens/event/all_events_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import '../../config/app_colors.dart';
+import 'package:radio_odan_app/config/app_routes.dart';
 
 import 'package:radio_odan_app/models/event_model.dart';
 import 'package:radio_odan_app/config/app_theme.dart';
@@ -242,8 +243,11 @@ class _AllEventsScreenState extends State<AllEventsScreen>
       elevation: 2,
       child: InkWell(
         onTap: () {
-          // TODO: buka detail event kalau sudah ada screen-nya
-          // context.read<EventProvider>().selectEvent(e, context);
+          Navigator.pushNamed(
+            context,
+            AppRoutes.eventDetail,
+            arguments: e,
+          );
         },
         borderRadius: BorderRadius.circular(12),
         child: Padding(

--- a/lib/screens/event/event_detail_screen.dart
+++ b/lib/screens/event/event_detail_screen.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
+import 'package:radio_odan_app/models/event_model.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
+import 'package:radio_odan_app/widgets/app_bar.dart';
+import 'package:radio_odan_app/widgets/mini_player.dart';
+
+class EventDetailScreen extends StatelessWidget {
+  final Event event;
+  const EventDetailScreen({super.key, required this.event});
+
+  Widget _thumbPlaceholder(BuildContext context) => Container(
+        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.9),
+        alignment: Alignment.center,
+        child: Icon(
+          Icons.image_not_supported,
+          size: 40,
+          color: Theme.of(context).colorScheme.onSurface.withOpacity(0.38),
+        ),
+      );
+
+  Widget _thumbLoading() => const Center(
+        child: SizedBox(
+          width: 22,
+          height: 22,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final url = event.gambarUrl;
+
+    return Scaffold(
+      appBar: CustomAppBar.transparent(title: event.judul),
+      backgroundColor: Theme.of(context).colorScheme.background,
+      body: Stack(
+        children: [
+          // Background gradient with bubbles
+          Positioned.fill(
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Theme.of(context).colorScheme.primary,
+                    Theme.of(context).colorScheme.background,
+                  ],
+                ),
+              ),
+              child: Stack(
+                children: [
+                  AppTheme.bubble(
+                    context,
+                    size: 200,
+                    top: 50,
+                    right: -50,
+                  ),
+                  AppTheme.bubble(
+                    context,
+                    size: 250,
+                    bottom: -50,
+                    left: -50,
+                    opacity: AppColors.bubbleDefaultOpacity * 0.6,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          // Content
+          SingleChildScrollView(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: SizedBox(
+                    width: double.infinity,
+                    height: 220,
+                    child: url.isEmpty
+                        ? _thumbPlaceholder(context)
+                        : CachedNetworkImage(
+                            imageUrl: url,
+                            fit: BoxFit.cover,
+                            placeholder: (_, __) => _thumbLoading(),
+                            errorWidget: (_, __, ___) =>
+                                _thumbPlaceholder(context),
+                          ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  event.judul,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.onSurface,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    const Icon(
+                      Icons.person_outline,
+                      size: 16,
+                      color: Colors.white,
+                    ),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        event.user ?? '-',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(
+                              color:
+                                  Theme.of(context).colorScheme.onSurface,
+                            ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    const Icon(
+                      Icons.calendar_today,
+                      size: 14,
+                      color: Colors.white,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      event.formattedTanggal,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  event.deskripsi,
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: MiniPlayer(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add EventDetailScreen for viewing event information
- register event detail route and link event cards to it

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4c4938c8832bae812dbcc6c194d8