### PR TITLE
chore: use example package name

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,7 +17,7 @@ val keystoreProperties = Properties().apply {
 }
 
 android {
-    namespace = "com.odanfm.radio"
+    namespace = "com.example.radioapp"
     compileSdk = flutter.compileSdkVersion
      ndkVersion = "27.0.12077973"
 
@@ -32,7 +32,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.odanfm.radio"
+        applicationId = "com.example.radioapp"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 23  // Required for Firebase Auth

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -9,7 +9,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:967860960628:android:b49ea298d7b150f5a68021",
         "android_client_info": {
-          "package_name": "com.odanfm.radio"
+          "package_name": "com.example.radioapp"
         }
       },
       "oauth_client": [
@@ -17,7 +17,7 @@
           "client_id": "967860960628-8gfb31a2nafea07168nndef3g3pdopsl.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "com.odanfm.radio",
+            "package_name": "com.example.radioapp",
             "certificate_hash": "afd24d253a1f524415d9a7ca3da8a890ec3d81fb"
           }
         },

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.radioapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/android/app/src/main/kotlin/com/example/radioapp/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/radioapp/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.odanfm.radio
+package com.example.radioapp
 
 import io.flutter.embedding.android.FlutterActivity
 


### PR DESCRIPTION
## Summary
- change Android applicationId and namespace to com.example.radioapp
- align AndroidManifest and Firebase config with new package name
- move and update MainActivity package declaration

## Testing
- `flutter build apk --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4f092dac832bb8f658430d4c6bbd