### PR TITLE
Use theme colors for chat bubbles

### DIFF
--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -73,8 +73,10 @@ class AppColors {
   static const Color lightCardSurface = Color(0xFFFFFFFF);
   static const Color lightDivider = Color(0x1F000000);
   static const Color lightBorder = Color(0xFFDADCE0);
-  static const Color lightBubble = Color(0xFFBBDEFB);
-  static const Color lightBubbleText = Color(0xFF0D47A1);
+  static const Color lightSentBubble = lightPrimary;
+  static const Color lightSentBubbleText = Color(0xFFFFFFFF);
+  static const Color lightReceivedBubble = Color(0xFFEEEEEE);
+  static const Color lightReceivedBubbleText = Color(0xDD000000);
 
   // ========== Dark Theme ==========
   static const Color darkPrimary = Color(0xFF90CAF9); // Lighter blue for better visibility on dark backgrounds
@@ -91,8 +93,10 @@ class AppColors {
   static const Color darkCardSurface = Color(0xFF1E1E1E);
   static const Color darkDivider = Color(0x1FFFFFFF);
   static const Color darkBorder = Color(0xFF424242);
-  static const Color darkBubble = Color(0xFF1E1E1E);
-  static const Color darkBubbleText = Color(0xFFFFFFFF);
+  static const Color darkSentBubble = darkPrimary;
+  static const Color darkSentBubbleText = darkTextPrimary;
+  static const Color darkReceivedBubble = darkSurface;
+  static const Color darkReceivedBubbleText = Color(0xFFFFFFFF);
 
   // ========== Common Colors ==========
   static const Color accent = Color(0xFF34A853);

--- a/lib/config/color_scheme_extension.dart
+++ b/lib/config/color_scheme_extension.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'app_colors.dart';
+
+extension ChatColorScheme on ColorScheme {
+  Color get sentMessageBubble =>
+      brightness == Brightness.light
+          ? AppColors.lightSentBubble
+          : AppColors.darkSentBubble;
+
+  Color get receivedMessageBubble =>
+      brightness == Brightness.light
+          ? AppColors.lightReceivedBubble
+          : AppColors.darkReceivedBubble;
+
+  Color get sentMessageText =>
+      brightness == Brightness.light
+          ? AppColors.lightSentBubbleText
+          : AppColors.darkSentBubbleText;
+
+  Color get receivedMessageText =>
+      brightness == Brightness.light
+          ? AppColors.lightReceivedBubbleText
+          : AppColors.darkReceivedBubbleText;
+}

--- a/lib/screens/chat/widget/chat_message_item.dart
+++ b/lib/screens/chat/widget/chat_message_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../models/chat_model.dart';
+import '../../../config/color_scheme_extension.dart';
 
 class ChatMessageItem extends StatelessWidget {
   final ChatMessage message;
@@ -17,6 +18,8 @@ class ChatMessageItem extends StatelessWidget {
   Widget build(BuildContext context) {
     // batas lebar bubble maks 75% layar
     final maxBubbleWidth = MediaQuery.of(context).size.width * 0.75;
+    final colors = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
@@ -48,12 +51,10 @@ class ChatMessageItem extends StatelessWidget {
                   ),
                   child: Text(
                     isCurrentUser ? 'You' : message.username,
-                    style: TextStyle(
+                    style: textTheme.labelMedium?.copyWith(
                       fontWeight: FontWeight.w500,
-                      fontSize: 13.0,
-                      color: isCurrentUser
-                          ? Theme.of(context).primaryColor
-                          : Colors.grey,
+                      color:
+                          isCurrentUser ? colors.primary : colors.onSurfaceVariant,
                     ),
                   ),
                 ),
@@ -65,8 +66,8 @@ class ChatMessageItem extends StatelessWidget {
                   ),
                   decoration: BoxDecoration(
                     color: isCurrentUser
-                        ? Theme.of(context).primaryColor
-                        : Colors.grey[200],
+                        ? colors.sentMessageBubble
+                        : colors.receivedMessageBubble,
                     borderRadius: BorderRadius.only(
                       topLeft: const Radius.circular(12.0),
                       topRight: const Radius.circular(12.0),
@@ -87,9 +88,10 @@ class ChatMessageItem extends StatelessWidget {
                   ),
                   child: Text(
                     message.message,
-                    style: TextStyle(
-                      color: isCurrentUser ? Colors.white : Colors.black87,
-                      fontSize: 15.0,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: isCurrentUser
+                          ? colors.sentMessageText
+                          : colors.receivedMessageText,
                     ),
                   ),
                 ),
@@ -101,7 +103,9 @@ class ChatMessageItem extends StatelessWidget {
                   ),
                   child: Text(
                     time,
-                    style: TextStyle(color: Colors.grey[500], fontSize: 11.0),
+                    style: textTheme.labelSmall?.copyWith(
+                      color: colors.onSurfaceVariant,
+                    ),
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- add light/dark chat bubble colors for sent vs. received
- expose bubble colors via ColorScheme extension
- refactor chat message widget to use colorScheme and textTheme

## Testing
- `flutter format lib/config/app_colors.dart lib/config/color_scheme_extension.dart lib/screens/chat/widget/chat_message_item.dart` *(fails: command not found: flutter)*
- `flutter analyze` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba82b84970832b89d8b433850d3172