### PR TITLE
refactor: use theme colors in chat

### DIFF
--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -107,7 +107,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Failed to send message: $e'),
-          backgroundColor: Colors.red,
+          backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );
     }
@@ -116,7 +116,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
   void _showOnlineUsers(BuildContext context, LiveChatProvider prov) {
     showModalBottomSheet(
       context: context,
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
@@ -127,9 +127,12 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Text(
+                Text(
                   'Pengguna Online',
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black87),
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 16),
                 Flexible(
@@ -140,19 +143,26 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                       final user = prov.onlineUsers[index];
                       return ListTile(
                         leading: CircleAvatar(
-                          backgroundColor: Colors.grey[800],
+                          backgroundColor:
+                              Theme.of(context).colorScheme.primary,
                           child: Text(
                             user.username.substring(0, 1).toUpperCase(),
-                            style: const TextStyle(color: Colors.white),
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onPrimary),
                           ),
                         ),
                         title: Text(
                           user.username,
-                          style: const TextStyle(color: Colors.white),
+                          style: Theme.of(context).textTheme.bodyMedium,
                         ),
                         subtitle: Text(
                           'Bergabung ${prov.formatTime(user.joinTime)}',
-                          style: TextStyle(color: Colors.grey[400]),
+                          style: Theme.of(context).textTheme.bodySmall,
                         ),
                       );
                     },
@@ -276,10 +286,14 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                         ),
                         child: Text(
                           '$unreadCount pesan baru',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                          ),
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyMedium
+                              ?.copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onPrimary,
+                                  fontWeight: FontWeight.bold),
                         ),
                       ),
                     ),

--- a/lib/screens/chat/widget/chat_message_item.dart
+++ b/lib/screens/chat/widget/chat_message_item.dart
@@ -48,13 +48,16 @@ class ChatMessageItem extends StatelessWidget {
                   ),
                   child: Text(
                     isCurrentUser ? 'You' : message.username,
-                    style: TextStyle(
-                      fontWeight: FontWeight.w500,
-                      fontSize: 13.0,
-                      color: isCurrentUser
-                          ? Theme.of(context).primaryColor
-                          : Colors.grey,
-                    ),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          fontWeight: FontWeight.w500,
+                          fontSize: 13.0,
+                          color: isCurrentUser
+                              ? Theme.of(context).colorScheme.primary
+                              : Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.color,
+                        ),
                   ),
                 ),
                 Container(
@@ -87,10 +90,12 @@ class ChatMessageItem extends StatelessWidget {
                   ),
                   child: Text(
                     message.message,
-                    style: TextStyle(
-                      color: isCurrentUser ? Colors.white : Colors.black87,
-                      fontSize: 15.0,
-                    ),
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: isCurrentUser
+                              ? Theme.of(context).colorScheme.onPrimary
+                              : Theme.of(context).colorScheme.onSurface,
+                          fontSize: 15.0,
+                        ),
                   ),
                 ),
                 Padding(
@@ -101,7 +106,10 @@ class ChatMessageItem extends StatelessWidget {
                   ),
                   child: Text(
                     time,
-                    style: TextStyle(color: Colors.grey[500], fontSize: 11.0),
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(fontSize: 11.0),
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- use Theme.of(context).colorScheme and textTheme for chat bottom sheet styling
- apply textTheme-based colors to chat messages and unread indicator

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba82a83d04832b9bfa2e53d43076cb