### PR TITLE
Use theme colors for surfaces and text styles

### DIFF
--- a/lib/screens/player/player_screen.dart
+++ b/lib/screens/player/player_screen.dart
@@ -73,26 +73,25 @@ class _FullPlayerState extends State<FullPlayer> {
         : currentStation?.host ?? '';
 
     if (currentStation == null) {
-      return const Scaffold(
-        backgroundColor: AppColors.backgroundDark,
+      return Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.background,
         body: Center(
           child: Text(
             'No radio station selected',
-            style: TextStyle(color: AppColors.white),
+            style: Theme.of(context).textTheme.bodyMedium,
           ),
         ),
       );
     }
     return Scaffold(
-      backgroundColor: AppColors.backgroundDark,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
-        title: const Text(
+        title: Text(
           "Now Playing",
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-          ),
+          style: Theme.of(context)
+              .textTheme
+              .titleMedium
+              ?.copyWith(fontWeight: FontWeight.bold),
         ),
         centerTitle: true,
         backgroundColor: AppColors.transparent,
@@ -149,11 +148,10 @@ class _FullPlayerState extends State<FullPlayer> {
                 children: [
                   Text(
                     title,
-                    style: const TextStyle(
-                      fontSize: 22,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                    ),
+                    style: Theme.of(context)
+                        .textTheme
+                        .headlineSmall
+                        ?.copyWith(fontSize: 22, fontWeight: FontWeight.bold),
                     textAlign: TextAlign.center,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
@@ -161,10 +159,7 @@ class _FullPlayerState extends State<FullPlayer> {
                   const SizedBox(height: 4),
                   Text(
                     artist,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      color: AppColors.textSecondary,
-                    ),
+                    style: Theme.of(context).textTheme.bodyMedium,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -178,13 +173,14 @@ class _FullPlayerState extends State<FullPlayer> {
                       color: AppColors.liveBadge,
                       borderRadius: BorderRadius.circular(16),
                     ),
-                    child: const Text(
+                    child: Text(
                       "LIVE",
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                      ),
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelSmall
+                          ?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold),
                     ),
                   ),
                 ],
@@ -249,29 +245,32 @@ class _FullPlayerState extends State<FullPlayer> {
                             isFavorited
                                 ? Icons.favorite
                                 : Icons.favorite_border,
-                            color: isFavorited
-                                ? const Color(0xFF1DB954)
-                                : Colors.grey,
-                          ),
+                              color: isFavorited
+                                  ? Theme.of(context).colorScheme.secondary
+                                  : Colors.grey,
+                            ),
                           iconSize: 28,
                           onPressed: () {
                             setState(() => isFavorited = !isFavorited);
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(
-                                  isFavorited
-                                      ? 'Added to favorites'
-                                      : 'Removed from favorites',
-                                  style: const TextStyle(color: Colors.white),
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(
+                                    isFavorited
+                                        ? 'Added to favorites'
+                                        : 'Removed from favorites',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodyMedium
+                                        ?.copyWith(color: Colors.white),
+                                  ),
+                                  backgroundColor: isFavorited
+                                      ? Theme.of(context).colorScheme.secondary
+                                      : Colors.grey,
                                 ),
-                                backgroundColor: isFavorited
-                                    ? const Color(0xFF1DB954)
-                                    : Colors.grey,
-                              ),
-                            );
-                          },
-                        ),
-                        const SizedBox(width: 25),
+                              );
+                            },
+                          ),
+                          const SizedBox(width: 25),
 
                         // Play / Pause
                         Container(
@@ -282,18 +281,21 @@ class _FullPlayerState extends State<FullPlayer> {
                             borderRadius: BorderRadius.circular(32),
                           ),
                           child: isLoading
-                              ? const Center(
-                                  child: CircularProgressIndicator(
-                                    color: Color(0xFF121212),
-                                    strokeWidth: 2,
-                                  ),
-                                )
+                              ? Center(
+                                    child: CircularProgressIndicator(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .surface,
+                                      strokeWidth: 2,
+                                    ),
+                                  )
                               : IconButton(
                                   iconSize: 40,
-                                  color: const Color(0xFF121212),
-                                  icon: Icon(
-                                    isPlaying ? Icons.pause : Icons.play_arrow,
-                                  ),
+                                    color:
+                                        Theme.of(context).colorScheme.surface,
+                                    icon: Icon(
+                                      isPlaying ? Icons.pause : Icons.play_arrow,
+                                    ),
                                   onPressed: () async {
                                     await radioProvider.togglePlayPause();
                                   },

--- a/lib/screens/program/program_detail_screen.dart
+++ b/lib/screens/program/program_detail_screen.dart
@@ -48,7 +48,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
 
   Widget _buildInfoCard(String title, String value, {IconData? icon}) {
     return Card(
-      color: const Color(0xFF1E1E1E),
+      color: Theme.of(context).colorScheme.surface,
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: Padding(
@@ -63,9 +63,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                   const SizedBox(width: 8),
                   Text(
                     title,
-                    style: const TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 14,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       fontWeight: FontWeight.w500,
                     ),
                   ),
@@ -74,9 +72,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
             else
               Text(
                 title,
-                style: const TextStyle(
-                  color: AppColors.textSecondary,
-                  fontSize: 14,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   fontWeight: FontWeight.w500,
                 ),
               ),
@@ -88,7 +84,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                       "body": Style(
                         margin: Margins.zero,
                         padding: HtmlPaddings.zero,
-                        color: AppColors.textPrimary,
+                        color: Theme.of(context).textTheme.bodyMedium?.color,
                         fontSize: FontSize(14.0),
                         lineHeight: LineHeight(1.5),
                       ),
@@ -119,7 +115,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
         borderRadius: BorderRadius.circular(12),
         child: url.isEmpty
             ? Container(
-                color: const Color(0xFF1E1E1E),
+                color: Theme.of(context).colorScheme.surface,
                 child: const Center(
                   child: Icon(
                     Icons.radio,
@@ -139,7 +135,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                   ),
                 ),
                 errorWidget: (_, __, ___) => Container(
-                  color: const Color(0xFF1E1E1E),
+                  color: Theme.of(context).colorScheme.surface,
                   child: const Center(
                     child: Icon(
                       Icons.radio,
@@ -162,7 +158,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
         final error = prov.detailError;
 
         return Scaffold(
-          backgroundColor: AppColors.backgroundDark,
+          backgroundColor: Theme.of(context).colorScheme.background,
           appBar: CustomAppBar.transparent(
             context: context,
             title: program?.namaProgram ?? 'Detail Program',
@@ -232,16 +228,14 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                         const SizedBox(height: 16),
                         Text(
                           'Gagal memuat detail program',
-                          style: Theme.of(context).textTheme.titleMedium
-                              ?.copyWith(color: AppColors.textPrimary),
+                          style:
+                              Theme.of(context).textTheme.titleMedium,
                         ),
                         const SizedBox(height: 8),
                         Text(
                           error,
                           textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            color: AppColors.textSecondary,
-                          ),
+                          style: Theme.of(context).textTheme.bodyMedium,
                         ),
                         const SizedBox(height: 16),
                         ElevatedButton(
@@ -265,8 +259,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                       const SizedBox(height: 16),
                       Text(
                         'Program tidak ditemukan',
-                        style: Theme.of(context).textTheme.titleMedium
-                            ?.copyWith(color: AppColors.textPrimary),
+                        style: Theme.of(context).textTheme.titleMedium,
                       ),
                     ],
                   ),
@@ -288,12 +281,10 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                               ),
                               child: Text(
                                 program.namaProgram,
-                                style: const TextStyle(
-                                  fontSize: 24,
-                                  fontWeight: FontWeight.bold,
-                                  color: AppColors.textPrimary,
-                                  height: 1.2,
-                                ),
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .displaySmall
+                                    ?.copyWith(height: 1.2),
                               ),
                             ),
                             const SizedBox(height: 16),

--- a/lib/widgets/common/mini_player.dart
+++ b/lib/widgets/common/mini_player.dart
@@ -56,21 +56,21 @@ class _MiniPlayerState extends State<MiniPlayer> {
         // Use pushNamed to navigate to the full player screen
         Navigator.of(context).pushNamed(AppRoutes.fullPlayer);
       },
-      child: Container(
-        height: 55,
-        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(8),
-          color: const Color(0xF3200C18),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.2),
-              blurRadius: 4,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
+        child: Container(
+          height: 55,
+          margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            color: Theme.of(context).colorScheme.surface,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.2),
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
 
         child: Column(
           children: [
@@ -95,51 +95,48 @@ class _MiniPlayerState extends State<MiniPlayer> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          title,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w600,
-                            fontSize: 14,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        Text(
-                          artist,
-                          style: const TextStyle(
-                            color: Colors.grey,
-                            fontSize: 12,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-                    ),
+                    children: [
+                      Text(
+                        title,
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(fontWeight: FontWeight.w600),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Text(
+                        artist,
+                        style: Theme.of(context).textTheme.bodySmall,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ),
+                ),
 
                   /// === LIVE + Play Button ===
                   Row(
                     children: [
                       // Tulisan LIVE
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 6,
-                          vertical: 2,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.red,
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: const Text(
-                          "LIVE",
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 10,
-                            fontWeight: FontWeight.bold,
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.red,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            "LIVE",
+                            style: Theme.of(context)
+                                .textTheme
+                                .labelSmall
+                                ?.copyWith(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.bold),
                           ),
                         ),
-                      ),
-                      const SizedBox(width: 8),
+                        const SizedBox(width: 8),
 
                       /// StreamBuilder untuk pantau state player
                       StreamBuilder<PlayerState>(


### PR DESCRIPTION
## Summary
- replace hard-coded surface hex colors with Theme.of(context).colorScheme.surface
- use Theme.of(context).textTheme for titles, labels, and messages
- hook favorite and play controls into app color scheme

## Testing
- `dart format lib/screens/program/program_detail_screen.dart lib/widgets/common/mini_player.dart lib/screens/player/player_screen.dart` *(fails: command not found)*
- `flutter format lib/screens/program/program_detail_screen.dart lib/widgets/common/mini_player.dart lib/screens/player/player_screen.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba82a484e8832bb959e8f47733703f