### PR TITLE
refactor: centralize color usage

### DIFF
--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -143,6 +143,18 @@ class AppColors {
   static const Color brown = Colors.brown;
   static const Color grey = Colors.grey;
   static const Color blueGrey = Colors.blueGrey;
+  static const Color redAccent = Colors.redAccent;
+  static const Color amber300 = Color(0xFFFFD54F);
+  static const Color orange700 = Color(0xFFF57C00);
+  static const Color grey100 = Color(0xFFF5F5F5);
+  static const Color grey200 = Color(0xFFEEEEEE);
+  static const Color grey300 = Color(0xFFE0E0E0);
+  static const Color grey400 = Color(0xFFBDBDBD);
+  static const Color grey600 = Color(0xFF757575);
+  static const Color grey700 = Color(0xFF616161);
+  static const Color grey800 = Color(0xFF424242);
+  static const Color grey850 = Color(0xFF303030);
+  static const Color white24 = Color(0x3DFFFFFF);
 
   // ========== Live/Streaming Colors ==========
   Color get liveIndicator => player.liveIndicator;

--- a/lib/navigation/bottom_nav.dart
+++ b/lib/navigation/bottom_nav.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 import 'package:radio_odan_app/providers/live_chat_provider.dart';
 import 'package:radio_odan_app/screens/home/home_screen.dart';
@@ -54,7 +55,10 @@ class _BottomNavState extends State<BottomNav> {
                 gradient: LinearGradient(
                   begin: Alignment.bottomCenter,
                   end: Alignment.topCenter,
-                  colors: [Colors.black.withOpacity(0.9), Colors.transparent],
+                  colors: [
+                    AppColors.black.withOpacity(0.9),
+                    AppColors.transparent,
+                  ],
                 ),
               ),
               child: const MiniPlayer(),
@@ -69,7 +73,7 @@ class _BottomNavState extends State<BottomNav> {
           bottomNavigationBarTheme: BottomNavigationBarThemeData(
             backgroundColor: Theme.of(context).scaffoldBackgroundColor,
             selectedItemColor: Theme.of(context).primaryColor,
-            unselectedItemColor: Colors.grey.shade600,
+            unselectedItemColor: AppColors.grey600,
             selectedLabelStyle: const TextStyle(fontWeight: FontWeight.w600),
             unselectedLabelStyle: const TextStyle(
               fontWeight: FontWeight.normal,
@@ -85,7 +89,7 @@ class _BottomNavState extends State<BottomNav> {
             color: Theme.of(context).colorScheme.surface,
             boxShadow: [
               BoxShadow(
-                color: Colors.grey.withOpacity(0.1),
+                color: AppColors.grey.withOpacity(0.1),
                 blurRadius: 10,
                 offset: const Offset(0, -2),
               ),

--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -34,7 +34,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('Link reset password telah dikirim. Cek email Anda.'),
-          backgroundColor: Colors.green,
+          backgroundColor: AppColors.green,
         ),
       );
       // Arahkan ke layar verifikasi/info atau kembali ke login
@@ -46,7 +46,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
     } else {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text(err), backgroundColor: Colors.red));
+      ).showSnackBar(SnackBar(content: Text(err), backgroundColor: AppColors.red));
     }
   }
 
@@ -119,7 +119,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                                     height: 20,
                                     child: CircularProgressIndicator(
                                       strokeWidth: 2,
-                                      color: Colors.white,
+                                      color: AppColors.white,
                                     ),
                                   )
                                 : const Text('Kirim Link Reset'),

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -490,7 +490,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                     ),
                                     style: OutlinedButton.styleFrom(
                                       side: const BorderSide(
-                                        color: Colors.grey,
+                                        color: AppColors.grey,
                                       ),
                                       shape: RoundedRectangleBorder(
                                         borderRadius: BorderRadius.circular(8),

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -81,7 +81,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: const Text('Anda harus menyetujui Syarat & Ketentuan'),
-            backgroundColor: Colors.orange.shade700,
+            backgroundColor: AppColors.orange700,
             behavior: SnackBarBehavior.floating,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
@@ -333,7 +333,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         'Buat Akun Baru',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.headlineSmall?.copyWith(
-                          color: Colors.white,
+                          color: AppColors.white,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
@@ -350,7 +350,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       // Name
                       TextFormField(
                         controller: _nameC,
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(color: AppColors.white),
                         decoration: _inputDecoration(
                           context,
                           label: 'Nama Lengkap',
@@ -365,7 +365,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       TextFormField(
                         controller: _emailC,
                         keyboardType: TextInputType.emailAddress,
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(color: AppColors.white),
                         decoration: _inputDecoration(
                           context,
                           label: 'Email',
@@ -380,7 +380,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       TextFormField(
                         controller: _passC,
                         obscureText: _obscure,
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(color: AppColors.white),
                         decoration: _inputDecoration(
                           context,
                           label: 'Password',
@@ -407,13 +407,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       // Strength bar
                       LinearProgressIndicator(
                         value: strength,
-                        backgroundColor: Colors.grey[800],
+                        backgroundColor: AppColors.grey800,
                         valueColor: AlwaysStoppedAnimation<Color>(
                           strength < 0.3
                               ? colorScheme.error
                               : (strength < 0.7
-                                  ? Colors.orange
-                                  : Colors.green),
+                                  ? AppColors.orange
+                                  : AppColors.green),
                         ),
                       ),
                       const SizedBox(height: 8),
@@ -422,7 +422,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       TextFormField(
                         controller: _confirmC,
                         obscureText: _obscure,
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(color: AppColors.white),
                         decoration: _inputDecoration(
                           context,
                           label: 'Konfirmasi Password',
@@ -444,8 +444,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                       setState(() => _agreeTerms = v ?? false),
                             fillColor: WidgetStateProperty.resolveWith<Color>(
                               (states) => states.contains(WidgetState.selected)
-                                  ? Colors.white
-                                  : Colors.transparent,
+                                  ? AppColors.white
+                                  : AppColors.transparent,
                             ),
                             side: BorderSide(
                               color: colorScheme.onSurface.withOpacity(0.7),
@@ -465,7 +465,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                   const TextSpan(
                                     text: 'Syarat & Ketentuan',
                                     style: TextStyle(
-                                      color: Colors.white,
+                                      color: AppColors.white,
                                       fontWeight: FontWeight.bold,
                                       decoration: TextDecoration.underline,
                                     ),
@@ -479,7 +479,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                   const TextSpan(
                                     text: 'Kebijakan Privasi',
                                     style: TextStyle(
-                                      color: Colors.white,
+                                      color: AppColors.white,
                                       fontWeight: FontWeight.bold,
                                       decoration: TextDecoration.underline,
                                     ),
@@ -496,7 +496,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ElevatedButton(
                         onPressed: loading ? null : _register,
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.white,
+                          backgroundColor: AppColors.white,
                           foregroundColor: AppColors.primary,
                           padding: const EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
@@ -563,7 +563,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         label: const Text(
                           'Google',
                           style: TextStyle(
-                            color: Colors.white,
+                            color: AppColors.white,
                             fontWeight: FontWeight.w500,
                           ),
                         ),
@@ -604,7 +604,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                             child: const Text(
                               'Masuk di sini',
                               style: TextStyle(
-                                color: Colors.white,
+                                color: AppColors.white,
                                 fontWeight: FontWeight.bold,
                                 decoration: TextDecoration.underline,
                               ),
@@ -622,10 +622,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
           // Loading overlay
           if (loading)
             Container(
-              color: Colors.black26,
+              color: AppColors.black.withOpacity(0.26),
               child: const Center(
                 child: CircularProgressIndicator(
-                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  valueColor: AlwaysStoppedAnimation<Color>(AppColors.white),
                 ),
               ),
             ),

--- a/lib/screens/auth/reset_password_screen.dart
+++ b/lib/screens/auth/reset_password_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:radio_odan_app/services/auth_service.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class ResetPasswordScreen extends StatefulWidget {
   final String email; // bisa diisi otomatis dari argumen
@@ -51,14 +52,14 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('Password berhasil direset. Silakan login.'),
-          backgroundColor: Colors.green,
+          backgroundColor: AppColors.green,
         ),
       );
       Navigator.pushNamedAndRemoveUntil(context, AppRoutes.login, (r) => false);
     } else {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text(err), backgroundColor: Colors.red));
+      ).showSnackBar(SnackBar(content: Text(err), backgroundColor: AppColors.red));
     }
   }
 
@@ -123,7 +124,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
                           height: 20,
                           child: CircularProgressIndicator(
                             strokeWidth: 2,
-                            color: Colors.white,
+                            color: AppColors.white,
                           ),
                         )
                       : const Text('Reset Password'),

--- a/lib/screens/auth/verification_screen.dart
+++ b/lib/screens/auth/verification_screen.dart
@@ -127,7 +127,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(msg),
-        backgroundColor: ok ? Colors.green : Colors.red,
+        backgroundColor: ok ? AppColors.green : AppColors.red,
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       ),
@@ -145,7 +145,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
     if (_initialLoading) {
       return const Scaffold(
         backgroundColor: AppColors.primary,
-        body: Center(child: CircularProgressIndicator(color: Colors.white)),
+        body: Center(child: CircularProgressIndicator(color: AppColors.white)),
       );
     }
 
@@ -192,10 +192,10 @@ class _VerificationScreenState extends State<VerificationScreen> {
                     Container(
                       padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.1),
+                        color: AppColors.white.withOpacity(0.1),
                         borderRadius: BorderRadius.circular(16),
                         border: Border.all(
-                          color: Colors.white.withOpacity(0.2),
+                          color: AppColors.white.withOpacity(0.2),
                           width: 1,
                         ),
                       ),
@@ -288,7 +288,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                                 height: 18,
                                 child: CircularProgressIndicator(
                                   strokeWidth: 2,
-                                  color: Colors.white,
+                                  color: AppColors.white,
                                 ),
                               )
                             : const Icon(Icons.verified),

--- a/lib/widgets/common/app_bar.dart
+++ b/lib/widgets/common/app_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
@@ -52,7 +53,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
 
     return CustomAppBar(
       title: title,
-      backgroundColor: Colors.transparent,
+      backgroundColor: AppColors.transparent,
       elevation: 0,
       titleColor: titleColor ?? theme.textTheme.titleLarge?.color,
       iconColor: iconColor ?? theme.iconTheme.color,
@@ -64,7 +65,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
             colors: [
-              Colors.transparent,
+              AppColors.transparent,
               isDark
                   ? theme.colorScheme.surface.withOpacity(0.7)
                   : theme.colorScheme.primary.withOpacity(0.8),

--- a/lib/widgets/common/app_drawer.dart
+++ b/lib/widgets/common/app_drawer.dart
@@ -7,6 +7,7 @@ import 'package:radio_odan_app/providers/user_provider.dart';
 import 'package:radio_odan_app/providers/theme_provider.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
 import 'package:radio_odan_app/services/user_service.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class AppDrawer extends StatelessWidget {
   const AppDrawer({super.key});
@@ -144,7 +145,7 @@ class AppDrawer extends StatelessWidget {
                                   context: context,
                                   icon: Icons.logout_rounded,
                                   title: "Logout",
-                                  iconColor: Colors.redAccent,
+                                  iconColor: AppColors.redAccent,
                                   onTap: () async {
                                     await UserService.logout();
                                     if (context.mounted) {
@@ -241,7 +242,7 @@ class AppDrawer extends StatelessWidget {
     if (userProvider.isLoading) {
       return CircleAvatar(
         radius: size / 2,
-        backgroundColor: Colors.white24,
+        backgroundColor: AppColors.white24,
         child: const SizedBox(
           width: 20,
           height: 20,
@@ -258,7 +259,7 @@ class AppDrawer extends StatelessWidget {
         imageUrl: url,
         imageBuilder: (context, imageProvider) => CircleAvatar(
           radius: size / 2,
-          backgroundColor: Colors.white,
+          backgroundColor: AppColors.white,
           child: CircleAvatar(
             radius: (size / 2) - 3,
             backgroundImage: imageProvider,
@@ -266,7 +267,7 @@ class AppDrawer extends StatelessWidget {
         ),
         placeholder: (_, __) => CircleAvatar(
           radius: size / 2,
-          backgroundColor: Colors.white24,
+          backgroundColor: AppColors.white24,
           child: const SizedBox(
             width: 20,
             height: 20,
@@ -274,12 +275,12 @@ class AppDrawer extends StatelessWidget {
           ),
         ),
         errorWidget: (_, __, ___) =>
-            _buildInitialsAvatar(size, Colors.blueGrey, user),
+            _buildInitialsAvatar(size, AppColors.blueGrey, user),
       );
     }
 
     // Fallback ke inisial
-    return _buildInitialsAvatar(size, Colors.blueGrey, user);
+    return _buildInitialsAvatar(size, AppColors.blueGrey, user);
   }
 
   Widget _buildInitialsAvatar(double size, Color color, UserModel? user) {
@@ -294,7 +295,7 @@ class AppDrawer extends StatelessWidget {
       child: Text(
         initial,
         style: const TextStyle(
-          color: Colors.white,
+          color: AppColors.white,
           fontWeight: FontWeight.bold,
           fontSize: 20,
         ),
@@ -319,12 +320,12 @@ class AppDrawer extends StatelessWidget {
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       decoration: BoxDecoration(
         color: isDark
-            ? Colors.white.withOpacity(0.1)
+            ? AppColors.white.withOpacity(0.1)
             : colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: isDark
-              ? Colors.white.withOpacity(0.1)
+              ? AppColors.white.withOpacity(0.1)
               : colorScheme.outlineVariant,
         ),
       ),
@@ -334,7 +335,7 @@ class AppDrawer extends StatelessWidget {
           width: 40,
           decoration: BoxDecoration(
             color: isDark
-                ? Colors.white.withOpacity(0.15)
+                ? AppColors.white.withOpacity(0.15)
                 : colorScheme.surfaceContainerHigh,
             borderRadius: BorderRadius.circular(12),
           ),
@@ -354,7 +355,7 @@ class AppDrawer extends StatelessWidget {
         ),
         onTap: onTap,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        hoverColor: Colors.white.withOpacity(0.1),
+        hoverColor: AppColors.white.withOpacity(0.1),
       ),
     );
   }

--- a/lib/widgets/common/mini_player.dart
+++ b/lib/widgets/common/mini_player.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:provider/provider.dart';
 import 'package:radio_odan_app/audio/audio_player_manager.dart';
@@ -23,7 +24,8 @@ class _MiniPlayerState extends State<MiniPlayer> {
       height: 42,
       fit: BoxFit.contain,
       errorBuilder: (context, error, stackTrace) =>
-          const Icon(Icons.music_note, size: 24, color: Colors.white70),
+          Icon(Icons.music_note, size: 24,
+              color: AppColors.white.withOpacity(0.7)),
     );
   }
 
@@ -65,7 +67,7 @@ class _MiniPlayerState extends State<MiniPlayer> {
             color: Theme.of(context).colorScheme.surface,
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withOpacity(0.2),
+                color: AppColors.black.withOpacity(0.2),
                 blurRadius: 4,
                 offset: const Offset(0, 2),
               ),
@@ -123,7 +125,7 @@ class _MiniPlayerState extends State<MiniPlayer> {
                             vertical: 2,
                           ),
                           decoration: BoxDecoration(
-                            color: Colors.red,
+                            color: AppColors.red,
                             borderRadius: BorderRadius.circular(4),
                           ),
                           child: Text(
@@ -132,7 +134,7 @@ class _MiniPlayerState extends State<MiniPlayer> {
                                 .textTheme
                                 .labelSmall
                                 ?.copyWith(
-                                    color: Colors.white,
+                                    color: AppColors.white,
                                     fontWeight: FontWeight.bold),
                           ),
                         ),
@@ -162,7 +164,7 @@ class _MiniPlayerState extends State<MiniPlayer> {
                               radioProvider.isPlaying
                                   ? Icons.pause
                                   : Icons.play_arrow,
-                              color: Colors.white,
+                              color: AppColors.white,
                             ),
                             onPressed: () async {
                               await radioProvider.togglePlayPause();
@@ -191,8 +193,8 @@ class _MiniPlayerState extends State<MiniPlayer> {
                   height: 2, // ketebalan bar
                   child: LinearProgressIndicator(
                     value: progress,
-                    backgroundColor: Colors.white.withValues(alpha: 0.2),
-                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.red),
+                    backgroundColor: AppColors.white.withValues(alpha: 0.2),
+                    valueColor: const AlwaysStoppedAnimation<Color>(AppColors.red),
                   ),
                 );
               },

--- a/lib/widgets/common/section_title.dart
+++ b/lib/widgets/common/section_title.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class SectionTitle extends StatelessWidget {
   final String title;
@@ -26,7 +27,7 @@ class SectionTitle extends StatelessWidget {
                 const TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
-                  color: Colors.white,
+                  color: AppColors.white,
                   letterSpacing: 0.5,
                 ),
           ),
@@ -37,7 +38,7 @@ class SectionTitle extends StatelessWidget {
                 "Lihat Semua",
                 style: TextStyle(
                   fontSize: 14,
-                  color: Colors.amber[300],
+                  color: AppColors.amber300,
                   fontWeight: FontWeight.w500,
                 ),
               ),

--- a/lib/widgets/skeleton/album_list_skeleton.dart
+++ b/lib/widgets/skeleton/album_list_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class AlbumListSkeleton extends StatelessWidget {
   const AlbumListSkeleton({super.key});
@@ -18,13 +19,13 @@ class AlbumListSkeleton extends StatelessWidget {
       ),
       itemBuilder: (context, index) {
         return Shimmer.fromColors(
-          baseColor: Colors.grey[850]!, // dark theme base
-          highlightColor: Colors.grey[700]!, // shimmer highlight
+          baseColor: AppColors.grey850, // dark theme base
+          highlightColor: AppColors.grey700, // shimmer highlight
           child: Container(
             margin: const EdgeInsets.only(bottom: 16),
             height: 180,
             decoration: BoxDecoration(
-              color: Colors.grey[850],
+              color: AppColors.grey850,
               borderRadius: BorderRadius.circular(12),
             ),
           ),

--- a/lib/widgets/skeleton/all_programs_skeleton.dart
+++ b/lib/widgets/skeleton/all_programs_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class AllProgramsSkeleton extends StatelessWidget {
   final int itemCount;
@@ -19,13 +20,13 @@ class AllProgramsSkeleton extends StatelessWidget {
             children: [
               // Image placeholder
               Shimmer.fromColors(
-                baseColor: Colors.grey[850]!,
-                highlightColor: Colors.grey[700]!,
+                baseColor: AppColors.grey850,
+                highlightColor: AppColors.grey700,
                 child: Container(
                   width: 120,
                   height: 80,
                   decoration: BoxDecoration(
-                    color: Colors.grey[850],
+                    color: AppColors.grey850,
                     borderRadius: BorderRadius.circular(8),
                   ),
                 ),
@@ -37,39 +38,39 @@ class AllProgramsSkeleton extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Shimmer.fromColors(
-                      baseColor: Colors.grey[850]!,
-                      highlightColor: Colors.grey[700]!,
+                      baseColor: AppColors.grey850,
+                      highlightColor: AppColors.grey700,
                       child: Container(
                         width: double.infinity,
                         height: 16,
                         decoration: BoxDecoration(
-                          color: Colors.grey[850],
+                          color: AppColors.grey850,
                           borderRadius: BorderRadius.circular(4),
                         ),
                       ),
                     ),
                     const SizedBox(height: 8),
                     Shimmer.fromColors(
-                      baseColor: Colors.grey[850]!,
-                      highlightColor: Colors.grey[700]!,
+                      baseColor: AppColors.grey850,
+                      highlightColor: AppColors.grey700,
                       child: Container(
                         width: 100,
                         height: 14,
                         decoration: BoxDecoration(
-                          color: Colors.grey[850],
+                          color: AppColors.grey850,
                           borderRadius: BorderRadius.circular(4),
                         ),
                       ),
                     ),
                     const SizedBox(height: 12),
                     Shimmer.fromColors(
-                      baseColor: Colors.grey[850]!,
-                      highlightColor: Colors.grey[700]!,
+                      baseColor: AppColors.grey850,
+                      highlightColor: AppColors.grey700,
                       child: Container(
                         width: 60,
                         height: 12,
                         decoration: BoxDecoration(
-                          color: Colors.grey[850],
+                          color: AppColors.grey850,
                           borderRadius: BorderRadius.circular(4),
                         ),
                       ),

--- a/lib/widgets/skeleton/app_header_skeleton.dart
+++ b/lib/widgets/skeleton/app_header_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class AppHeaderSkeleton extends StatelessWidget {
   const AppHeaderSkeleton({super.key});
@@ -31,8 +32,8 @@ class AppHeaderSkeleton extends StatelessWidget {
         ],
       ),
       child: Shimmer.fromColors(
-        baseColor: isDark ? colorScheme.surfaceVariant : Colors.grey[300]!,
-        highlightColor: isDark ? colorScheme.surface : Colors.grey[100]!,
+        baseColor: isDark ? colorScheme.surfaceVariant : AppColors.grey300,
+        highlightColor: isDark ? colorScheme.surface : AppColors.grey100,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -55,7 +56,7 @@ class AppHeaderSkeleton extends StatelessWidget {
                   child: Text(
                     'ODAN FM',
                     style: TextStyle(
-                      color: Colors.transparent,
+                      color: AppColors.transparent,
                       fontSize: 20,
                       fontWeight: FontWeight.w800,
                       letterSpacing: 1.2,

--- a/lib/widgets/skeleton/artikel_all_skeleton.dart
+++ b/lib/widgets/skeleton/artikel_all_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class ArtikelAllSkeleton extends StatelessWidget {
   final int itemCount;
@@ -19,13 +20,13 @@ class ArtikelAllSkeleton extends StatelessWidget {
             children: [
               // Thumbnail shimmer
               Shimmer.fromColors(
-                baseColor: Colors.grey[850]!,
-                highlightColor: Colors.grey[700]!,
+                baseColor: AppColors.grey850,
+                highlightColor: AppColors.grey700,
                 child: Container(
                   width: 100,
                   height: 100,
                   decoration: BoxDecoration(
-                    color: Colors.grey[850],
+                    color: AppColors.grey850,
                     borderRadius: BorderRadius.circular(8),
                   ),
                 ),
@@ -38,12 +39,12 @@ class ArtikelAllSkeleton extends StatelessWidget {
                   children: [
                     // Judul shimmer
                     Shimmer.fromColors(
-                      baseColor: Colors.grey[850]!,
-                      highlightColor: Colors.grey[700]!,
+                      baseColor: AppColors.grey850,
+                      highlightColor: AppColors.grey700,
                       child: Container(
                         width: double.infinity,
                         height: 16,
-                        color: Colors.grey[850],
+                        color: AppColors.grey850,
                       ),
                     ),
                     const SizedBox(height: 6),
@@ -51,22 +52,22 @@ class ArtikelAllSkeleton extends StatelessWidget {
                     Row(
                       children: [
                         Shimmer.fromColors(
-                          baseColor: Colors.grey[850]!,
-                          highlightColor: Colors.grey[700]!,
+                          baseColor: AppColors.grey850,
+                          highlightColor: AppColors.grey700,
                           child: Container(
                             width: 60,
                             height: 12,
-                            color: Colors.grey[850],
+                            color: AppColors.grey850,
                           ),
                         ),
                         const SizedBox(width: 6),
                         Shimmer.fromColors(
-                          baseColor: Colors.grey[850]!,
-                          highlightColor: Colors.grey[700]!,
+                          baseColor: AppColors.grey850,
+                          highlightColor: AppColors.grey700,
                           child: Container(
                             width: 40,
                             height: 12,
-                            color: Colors.grey[850],
+                            color: AppColors.grey850,
                           ),
                         ),
                       ],
@@ -74,12 +75,12 @@ class ArtikelAllSkeleton extends StatelessWidget {
                     const SizedBox(height: 4),
                     // Date shimmer
                     Shimmer.fromColors(
-                      baseColor: Colors.grey[850]!,
-                      highlightColor: Colors.grey[700]!,
+                      baseColor: AppColors.grey850,
+                      highlightColor: AppColors.grey700,
                       child: Container(
                         width: 80,
                         height: 12,
-                        color: Colors.grey[850],
+                        color: AppColors.grey850,
                       ),
                     ),
                   ],

--- a/lib/widgets/skeleton/artikel_skeleton.dart
+++ b/lib/widgets/skeleton/artikel_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class ArtikelSkeleton extends StatelessWidget {
   final int itemCount;
@@ -23,13 +24,13 @@ class ArtikelSkeleton extends StatelessWidget {
               children: [
                 // shimmer gambar
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     height: 150,
                     width: 160,
                     decoration: BoxDecoration(
-                      color: Colors.grey[850],
+                      color: AppColors.grey850,
                       borderRadius: BorderRadius.circular(5),
                     ),
                   ),
@@ -37,23 +38,23 @@ class ArtikelSkeleton extends StatelessWidget {
                 const SizedBox(height: 8),
                 // shimmer judul
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     width: 120,
                     height: 16,
-                    color: Colors.grey[850],
+                    color: AppColors.grey850,
                   ),
                 ),
                 const SizedBox(height: 4),
                 // shimmer tanggal
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     width: 80,
                     height: 12,
-                    color: Colors.grey[850],
+                    color: AppColors.grey850,
                   ),
                 ),
               ],

--- a/lib/widgets/skeleton/event_skeleton.dart
+++ b/lib/widgets/skeleton/event_skeleton.dart
@@ -31,8 +31,8 @@ class EventCardSkeleton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Shimmer.fromColors(
-      baseColor: Colors.grey[800]!,
-      highlightColor: Colors.grey[700]!,
+      baseColor: AppColors.grey800,
+      highlightColor: AppColors.grey700,
       child: Card(
         color: AppColors.darkSurface.withOpacity(0.9),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
@@ -47,7 +47,7 @@ class EventCardSkeleton extends StatelessWidget {
                 aspectRatio: 16 / 9,
                 child: DecoratedBox(
                   decoration: BoxDecoration(
-                    color: Colors.white24,
+                    color: AppColors.white24,
                     borderRadius: BorderRadius.all(Radius.circular(8)),
                   ),
                 ),
@@ -58,7 +58,7 @@ class EventCardSkeleton extends StatelessWidget {
                 height: 20,
                 width: double.infinity,
                 decoration: BoxDecoration(
-                  color: Colors.white24,
+                  color: AppColors.white24,
                   borderRadius: BorderRadius.circular(4),
                 ),
               ),
@@ -68,7 +68,7 @@ class EventCardSkeleton extends StatelessWidget {
                 height: 16,
                 width: 120,
                 decoration: BoxDecoration(
-                  color: Colors.white24,
+                  color: AppColors.white24,
                   borderRadius: BorderRadius.circular(4),
                 ),
               ),

--- a/lib/widgets/skeleton/penyiar_skeleton.dart
+++ b/lib/widgets/skeleton/penyiar_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class PenyiarSkeleton extends StatelessWidget {
   final int itemCount;
@@ -20,25 +21,25 @@ class PenyiarSkeleton extends StatelessWidget {
             child: Column(
               children: [
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     width: 80,
                     height: 80,
                     decoration: BoxDecoration(
-                      color: Colors.grey[850],
+                      color: AppColors.grey850,
                       shape: BoxShape.circle,
                     ),
                   ),
                 ),
                 const SizedBox(height: 6),
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     width: 60,
                     height: 14,
-                    color: Colors.grey[850],
+                    color: AppColors.grey850,
                   ),
                 ),
               ],

--- a/lib/widgets/skeleton/program_skeleton.dart
+++ b/lib/widgets/skeleton/program_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class ProgramSkeleton extends StatelessWidget {
   final int itemCount;
@@ -25,13 +26,13 @@ class ProgramSkeleton extends StatelessWidget {
               children: [
                 // shimmer gambar
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!, // dark mode
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850, // dark mode
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     height: 225,
                     width: 160,
                     decoration: BoxDecoration(
-                      color: Colors.grey[850],
+                      color: AppColors.grey850,
                       borderRadius: BorderRadius.circular(5),
                     ),
                   ),
@@ -39,13 +40,13 @@ class ProgramSkeleton extends StatelessWidget {
                 const SizedBox(height: 8),
                 // shimmer judul program
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     width: 120,
                     height: 16,
                     decoration: BoxDecoration(
-                      color: Colors.grey[850],
+                      color: AppColors.grey850,
                       borderRadius: BorderRadius.circular(3),
                     ),
                   ),
@@ -53,13 +54,13 @@ class ProgramSkeleton extends StatelessWidget {
                 const SizedBox(height: 4),
                 // shimmer nama penyiar
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     width: 100,
                     height: 14,
                     decoration: BoxDecoration(
-                      color: Colors.grey[850],
+                      color: AppColors.grey850,
                       borderRadius: BorderRadius.circular(3),
                     ),
                   ),
@@ -67,13 +68,13 @@ class ProgramSkeleton extends StatelessWidget {
                 const SizedBox(height: 2),
                 // shimmer hari & jam
                 Shimmer.fromColors(
-                  baseColor: Colors.grey[850]!,
-                  highlightColor: Colors.grey[700]!,
+                  baseColor: AppColors.grey850,
+                  highlightColor: AppColors.grey700,
                   child: Container(
                     width: 80,
                     height: 12,
                     decoration: BoxDecoration(
-                      color: Colors.grey[850],
+                      color: AppColors.grey850,
                       borderRadius: BorderRadius.circular(3),
                     ),
                   ),

--- a/lib/widgets/skeleton/video_list_skeleton.dart
+++ b/lib/widgets/skeleton/video_list_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../config/app_colors.dart';
 
 class VideoListSkeleton extends StatelessWidget {
   const VideoListSkeleton({super.key});
@@ -13,8 +14,8 @@ class VideoListSkeleton extends StatelessWidget {
       separatorBuilder: (_, __) => const SizedBox(width: 16),
       itemBuilder: (context, index) {
         return Shimmer.fromColors(
-          baseColor: Colors.grey[850]!,
-          highlightColor: Colors.grey[700]!,
+          baseColor: AppColors.grey850,
+          highlightColor: AppColors.grey700,
           child: SizedBox(
             width: 270,
             height: 190, // Fixed height to match the parent constraint
@@ -26,7 +27,7 @@ class VideoListSkeleton extends StatelessWidget {
                   height: 160, // Reduced height to accommodate the text
                   width: double.infinity,
                   decoration: BoxDecoration(
-                    color: Colors.grey[850],
+                    color: AppColors.grey850,
                     borderRadius: BorderRadius.circular(8),
                   ),
                 ),
@@ -35,7 +36,7 @@ class VideoListSkeleton extends StatelessWidget {
                   height: 16,
                   width: 200,
                   decoration: BoxDecoration(
-                    color: Colors.grey[850],
+                    color: AppColors.grey850,
                     borderRadius: BorderRadius.circular(4),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- centralize color constants in AppColors
- replace hard-coded colors in auth screens, widgets, and skeletons with AppColors

## Testing
- `dart format lib/config/app_colors.dart lib/navigation/bottom_nav.dart lib/screens/auth/forgot_password_screen.dart lib/screens/auth/login_screen.dart lib/screens/auth/register_screen.dart lib/screens/auth/reset_password_screen.dart lib/screens/auth/verification_screen.dart lib/widgets/common/app_bar.dart lib/widgets/common/app_drawer.dart lib/widgets/common/mini_player.dart lib/widgets/common/section_title.dart lib/widgets/skeleton/album_list_skeleton.dart lib/widgets/skeleton/all_programs_skeleton.dart lib/widgets/skeleton/app_header_skeleton.dart lib/widgets/skeleton/artikel_all_skeleton.dart lib/widgets/skeleton/artikel_skeleton.dart lib/widgets/skeleton/event_skeleton.dart lib/widgets/skeleton/penyiar_skeleton.dart lib/widgets/skeleton/program_skeleton.dart lib/widgets/skeleton/video_list_skeleton.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bb6f638710832bb067cddaf902f95c