### PR TITLE
Prune unused color constants

### DIFF
--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -2,27 +2,11 @@ import 'package:flutter/material.dart';
 
 // ========== Component Color Classes ==========
 class _PlayerColors {
-  final Color background = const Color(0xFF121212);
   final Color controls = const Color(0xFFFFFFFF);
-  final Color progressBackground = const Color(0x4DFFFFFF);
-  final Color progressPlayed = const Color(0xFF1E88E5);
-  final Color progressBuffered = const Color(0x66FFFFFF);
-  final Color liveIndicator = const Color(0xFFFE2C55);
-  final Color liveBadge = const Color(0xFFFF0000);
 }
 
 class _ButtonColors {
-  final Color primary = const Color(0xFF1E88E5);
   final Color primaryText = const Color(0xFFFFFFFF);
-  final Color secondary = const Color(0x1FFFFFFF);
-  final Color secondaryText = const Color(0xFFFFFFFF);
-}
-
-class _InputColors {
-  static const Color background = Color(0x1AFFFFFF);
-  static const Color border = Color(0x33FFFFFF);
-  static const Color text = Color(0xFFFFFFFF);
-  static const Color hint = Color(0xB3FFFFFF);
 }
 
 class _ChatColors {
@@ -31,29 +15,6 @@ class _ChatColors {
   static const Color hintText = Color(0xFF9E9E9E);
 }
 
-class _TabColors {
-  static const Color selected = Color(0xFFFFFFFF);
-  static const Color unselected = Color(0xB3FFFFFF);
-  static const Color indicator = Color(0xFFFFFFFF);
-}
-
-class _LoadingColors {
-  static const Color shimmerBase = Color(0x1AFFFFFF);
-  static const Color shimmerHighlight = Color(0x33FFFFFF);
-}
-
-class _SocialMediaColors {
-  static const Color facebook = Color(0xFF1877F2);
-  static const Color twitter = Color(0xFF1DA1F2);
-  static const Color instagram = Color(0xFFE1306C);
-  static const Color youtube = Color(0xFFFF0000);
-  static const Color whatsapp = Color(0xFF25D366);
-}
-
-class _SystemUIColors {
-  static const Color statusBar = Color(0x00000000);
-  static const Color systemNavigationBar = Color(0xFF121212);
-}
 
 class AppColors {
   // ========== Light Theme ==========
@@ -72,7 +33,6 @@ class AppColors {
   ); // White for better contrast
   static const Color lightTextSecondary = Color(0xFFBBDEFB); // Light blue
   static const Color lightTextTertiary = Color(0xFF90CAF9); // Lighter blue
-  static const Color lightTextHint = Color(0xFF64B5F6); // Medium light blue
 
   // Light UI Colors
   static const Color lightCardSurface = Color(
@@ -98,7 +58,6 @@ class AppColors {
   static const Color darkTextPrimary = Color(0xFFFFFFFF);
   static const Color darkTextSecondary = Color(0xFFB0BEC5);
   static const Color darkTextTertiary = Color(0xFF757575);
-  static const Color darkTextHint = Color(0xFF9E9E9E);
 
   // Dark UI Colors
   static const Color darkCardSurface = Color(0xFF1E1E1E);
@@ -113,19 +72,11 @@ class AppColors {
   static const Color accent = Color(0xFF34A853);
   static const Color error = Color(0xFFB00020);
   static const Color success = Color(0xFF4CAF50);
-  static const Color warning = Color(0xFFFFC107);
-  static const Color info = Color(0xFF2196F3);
   static const Color disabled = Color(0xFF9E9E9E);
 
   // ========== Component Colors ==========
   static final player = _PlayerColors();
   static final button = _ButtonColors();
-  static final input = _InputColors();
-  static final chat = _ChatColors();
-  static final tab = _TabColors();
-  static final loading = _LoadingColors();
-  static final social = _SocialMediaColors();
-  static final systemUI = _SystemUIColors();
 
   // ========== Common Color Aliases ==========
   static const Color transparent = Colors.transparent;
@@ -133,32 +84,19 @@ class AppColors {
   static const Color black = Colors.black;
   static const Color red = Colors.red;
   static const Color green = Colors.green;
-  static const Color blue = Colors.blue;
-  static const Color yellow = Colors.yellow;
   static const Color orange = Colors.orange;
-  static const Color purple = Colors.purple;
-  static const Color pink = Colors.pink;
-  static const Color teal = Colors.teal;
-  static const Color cyan = Colors.cyan;
-  static const Color brown = Colors.brown;
   static const Color grey = Colors.grey;
   static const Color blueGrey = Colors.blueGrey;
   static const Color redAccent = Colors.redAccent;
   static const Color amber300 = Color(0xFFFFD54F);
   static const Color orange700 = Color(0xFFF57C00);
   static const Color grey100 = Color(0xFFF5F5F5);
-  static const Color grey200 = Color(0xFFEEEEEE);
   static const Color grey300 = Color(0xFFE0E0E0);
-  static const Color grey400 = Color(0xFFBDBDBD);
   static const Color grey600 = Color(0xFF757575);
   static const Color grey700 = Color(0xFF616161);
   static const Color grey800 = Color(0xFF424242);
   static const Color grey850 = Color(0xFF303030);
   static const Color white24 = Color(0x3DFFFFFF);
-
-  // ========== Live/Streaming Colors ==========
-  Color get liveIndicator => player.liveIndicator;
-  Color get liveBadge => player.liveBadge;
 
   // ========== Chat Colors ==========
   static const Color chatBackground = _ChatColors.background;
@@ -178,18 +116,6 @@ class AppColors {
   @Deprecated('Use AppColors.lightTextSecondary instead')
   static const Color textSecondary = lightTextSecondary;
 
-  @Deprecated('Use AppColors.lightTextTertiary instead')
-  static const Color textTertiary = lightTextTertiary;
-
-  @Deprecated('Use AppColors.lightTextHint instead')
-  static const Color textHint = lightTextHint;
-
   @Deprecated('Use AppColors.lightCardSurface instead')
   static const Color cardSurface = lightCardSurface;
-
-  @Deprecated('Use AppColors.lightDivider instead')
-  static const Color dividerColor = lightDivider;
-
-  @Deprecated('Use AppColors.lightBorder instead')
-  static const Color borderColor = lightBorder;
 }


### PR DESCRIPTION
## Summary
- remove unused component color classes and getters from `AppColors`
- drop unreferenced color aliases and deprecated constants
- keep chat colors and essential aliases only

## Testing
- `dart format lib/config/app_colors.dart` *(fails: command not found)*
- `flutter format lib/config/app_colors.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb715cf010832bb3b5d342035a43f7