### PR TITLE
refactor: remove deprecated color aliases

### DIFF
--- a/lib/config/README.md
+++ b/lib/config/README.md
@@ -41,7 +41,7 @@ Aplikasi mendukung tema terang dan gelap. Untuk menggunakan tema:
 theme: Theme.of(context),
 
 // Mengakses warna kustom
-color: AppColors.primary,
+color: AppColors.lightPrimary,
 
 // Menggunakan teks style
 textTheme: AppTheme.textTheme,

--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -103,19 +103,4 @@ class AppColors {
   static const Color chatInputBackground = _ChatColors.inputBackground;
   static const Color chatHintText = _ChatColors.hintText;
 
-  // ========== Deprecated (Kept for backward compatibility) ==========
-  @Deprecated('Use AppColors.lightPrimary instead')
-  static const Color primary = lightPrimary;
-
-  @Deprecated('Use AppColors.lightBackground instead')
-  static const Color backgroundDark = lightBackground;
-
-  @Deprecated('Use AppColors.lightTextPrimary instead')
-  static const Color textPrimary = lightTextPrimary;
-
-  @Deprecated('Use AppColors.lightTextSecondary instead')
-  static const Color textSecondary = lightTextSecondary;
-
-  @Deprecated('Use AppColors.lightCardSurface instead')
-  static const Color cardSurface = lightCardSurface;
 }

--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -60,7 +60,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           gradient: LinearGradient(
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
-            colors: [AppColors.primary, AppColors.backgroundDark],
+            colors: [AppColors.lightPrimary, AppColors.lightBackground],
           ),
         ),
         child: Center(

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -195,7 +195,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   gradient: LinearGradient(
                     begin: Alignment.topCenter,
                     end: Alignment.bottomCenter,
-                    colors: [AppColors.primary, AppColors.backgroundDark],
+                    colors: [AppColors.lightPrimary, AppColors.lightBackground],
                   ),
                 ),
                 child: SafeArea(

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -285,7 +285,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                 gradient: LinearGradient(
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
-                  colors: [AppColors.primary, AppColors.backgroundDark],
+                  colors: [AppColors.lightPrimary, AppColors.lightBackground],
                 ),
               ),
               child: Stack(
@@ -497,7 +497,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         onPressed: loading ? null : _register,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: AppColors.white,
-                          foregroundColor: AppColors.primary,
+                          foregroundColor: AppColors.lightPrimary,
                           padding: const EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12),
@@ -511,7 +511,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                 child: CircularProgressIndicator(
                                   strokeWidth: 2,
                                   valueColor: AlwaysStoppedAnimation<Color>(
-                                    AppColors.primary,
+                                    AppColors.lightPrimary,
                                   ),
                                 ),
                               )

--- a/lib/screens/auth/verification_screen.dart
+++ b/lib/screens/auth/verification_screen.dart
@@ -144,13 +144,13 @@ class _VerificationScreenState extends State<VerificationScreen> {
 
     if (_initialLoading) {
       return const Scaffold(
-        backgroundColor: AppColors.primary,
+        backgroundColor: AppColors.lightPrimary,
         body: Center(child: CircularProgressIndicator(color: AppColors.white)),
       );
     }
 
     return Scaffold(
-      backgroundColor: AppColors.primary,
+      backgroundColor: AppColors.lightPrimary,
       body: Stack(
         children: [
           // Background gradient
@@ -183,7 +183,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                       'Verifikasi Email',
                       textAlign: TextAlign.center,
                       style: theme.textTheme.headlineMedium?.copyWith(
-                        color: AppColors.textPrimary,
+                        color: AppColors.lightTextPrimary,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
@@ -204,13 +204,13 @@ class _VerificationScreenState extends State<VerificationScreen> {
                           const Icon(
                             Icons.mark_email_read_outlined,
                             size: 64,
-                            color: AppColors.textPrimary,
+                            color: AppColors.lightTextPrimary,
                           ),
                           const SizedBox(height: 16),
                           Text(
                             'Periksa Email Anda',
                             style: theme.textTheme.titleLarge?.copyWith(
-                              color: AppColors.textPrimary,
+                              color: AppColors.lightTextPrimary,
                               fontWeight: FontWeight.bold,
                             ),
                             textAlign: TextAlign.center,
@@ -219,7 +219,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                           Text(
                             'Kami telah mengirimkan link verifikasi ke:',
                             style: theme.textTheme.bodyMedium?.copyWith(
-                              color: AppColors.textSecondary,
+                              color: AppColors.lightTextSecondary,
                             ),
                             textAlign: TextAlign.center,
                           ),
@@ -227,7 +227,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                           Text(
                             widget.email,
                             style: theme.textTheme.bodyLarge?.copyWith(
-                              color: AppColors.textPrimary,
+                              color: AppColors.lightTextPrimary,
                               fontWeight: FontWeight.bold,
                             ),
                             textAlign: TextAlign.center,
@@ -236,7 +236,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                           Text(
                             'Klik link verifikasi di email Anda, lalu kembali ke aplikasi dan tekan "Cek status".',
                             style: theme.textTheme.bodyMedium?.copyWith(
-                              color: AppColors.textSecondary,
+                              color: AppColors.lightTextSecondary,
                             ),
                             textAlign: TextAlign.center,
                           ),
@@ -256,7 +256,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                             borderRadius: BorderRadius.circular(12),
                           ),
                           side: const BorderSide(
-                            color: AppColors.textPrimary,
+                            color: AppColors.lightTextPrimary,
                             width: 1.5,
                           ),
                         ),
@@ -309,7 +309,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                         'Kembali ke Halaman Login',
                         style: TextStyle(
                           fontSize: 16,
-                          color: AppColors.textPrimary,
+                          color: AppColors.lightTextPrimary,
                           decoration: TextDecoration.underline,
                         ),
                       ),

--- a/lib/screens/chat/widget/no_live_placeholder.dart
+++ b/lib/screens/chat/widget/no_live_placeholder.dart
@@ -39,7 +39,7 @@ class NoLivePlaceholder extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(20),
                   decoration: BoxDecoration(
-                    color: AppColors.cardSurface.withOpacity(0.7),
+                    color: AppColors.lightCardSurface.withOpacity(0.7),
                     shape: BoxShape.circle,
                     border: Border.all(
                       color: AppColors().liveIndicator.withOpacity(0.3),
@@ -70,7 +70,7 @@ class NoLivePlaceholder extends StatelessWidget {
               Text(
                 'Siaran belum dimulai atau sedang dalam jeda.\nNantikan siaran berikutnya!',
                 style: TextStyle(
-                  color: AppColors.textSecondary,
+                  color: AppColors.lightTextSecondary,
                   fontSize: 14,
                   height: 1.5,
                 ),

--- a/lib/screens/program/program_detail_screen.dart
+++ b/lib/screens/program/program_detail_screen.dart
@@ -59,7 +59,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
             if (icon != null)
               Row(
                 children: [
-                  Icon(icon, color: AppColors.textSecondary, size: 20),
+                  Icon(icon, color: AppColors.lightTextSecondary, size: 20),
                   const SizedBox(width: 8),
                   Text(
                     title,
@@ -93,7 +93,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                         padding: HtmlPaddings.only(bottom: 8.0),
                       ),
                       "a": Style(
-                        color: AppColors.primary,
+                        color: AppColors.lightPrimary,
                         textDecoration: TextDecoration.none,
                       ),
                       "strong": Style(fontWeight: FontWeight.bold),
@@ -120,7 +120,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                   child: Icon(
                     Icons.radio,
                     size: 80,
-                    color: AppColors.textSecondary,
+                    color: AppColors.lightTextSecondary,
                   ),
                 ),
               )
@@ -140,7 +140,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                     child: Icon(
                       Icons.radio,
                       size: 80,
-                      color: AppColors.textSecondary,
+                      color: AppColors.lightTextSecondary,
                     ),
                   ),
                 ),
@@ -254,7 +254,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                       const Icon(
                         Icons.radio,
                         size: 64,
-                        color: AppColors.textSecondary,
+                        color: AppColors.lightTextSecondary,
                       ),
                       const SizedBox(height: 16),
                       Text(

--- a/lib/screens/splash/splash_screen.dart
+++ b/lib/screens/splash/splash_screen.dart
@@ -28,7 +28,7 @@ class _SplashScreenState extends State<SplashScreen> {
           gradient: LinearGradient(
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
-            colors: [AppColors.primary, AppColors.backgroundDark],
+            colors: [AppColors.lightPrimary, AppColors.lightBackground],
           ),
         ),
         child: Stack(
@@ -42,7 +42,7 @@ class _SplashScreenState extends State<SplashScreen> {
                 height: 300,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: AppColors.backgroundDark.withValues(alpha: 0.1),
+                  color: AppColors.lightBackground.withValues(alpha: 0.1),
                 ),
               ),
             ),
@@ -54,7 +54,7 @@ class _SplashScreenState extends State<SplashScreen> {
                 height: 400,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: AppColors.backgroundDark.withValues(alpha: 0.1),
+                  color: AppColors.lightBackground.withValues(alpha: 0.1),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- replace uses of deprecated `AppColors` aliases with `light*` variants
- remove outdated alias definitions from `app_colors.dart`
- update docs to reference new color names

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb73ebe7c4832bbc1223d831a4e972