### PR TITLE
refactor: centralize theme colors with AppColors

### DIFF
--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -90,8 +90,12 @@ class AppColors {
   static const Color redAccent = Colors.redAccent;
   static const Color amber300 = Color(0xFFFFD54F);
   static const Color orange700 = Color(0xFFF57C00);
+  static const Color blue800 = Color(0xFF1565C0);
+  static const Color blueGrey800 = Color(0xFF37474F);
   static const Color grey100 = Color(0xFFF5F5F5);
+  static const Color grey200 = Color(0xFFEEEEEE);
   static const Color grey300 = Color(0xFFE0E0E0);
+  static const Color grey400 = Color(0xFFBDBDBD);
   static const Color grey600 = Color(0xFF757575);
   static const Color grey700 = Color(0xFF616161);
   static const Color grey800 = Color(0xFF424242);

--- a/lib/config/app_theme.dart
+++ b/lib/config/app_theme.dart
@@ -17,11 +17,11 @@ class AppTheme {
         surface: AppColors.lightCardSurface,
         background: AppColors.lightBackground,
         error: AppColors.error,
-        onPrimary: Colors.white,
-        onSecondary: Colors.white,
+        onPrimary: AppColors.white,
+        onSecondary: AppColors.white,
         onSurface: AppColors.lightTextPrimary,
         onBackground: AppColors.lightTextPrimary,
-        onError: Colors.white,
+        onError: AppColors.white,
         brightness: Brightness.light,
       ),
       textTheme: TextTheme(
@@ -70,9 +70,9 @@ class AppTheme {
         titleTextStyle: const TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.w700,
-          color: Colors.white,
+          color: AppColors.white,
         ),
-        iconTheme: const IconThemeData(color: Colors.white, size: 24),
+        iconTheme: const IconThemeData(color: AppColors.white, size: 24),
         systemOverlayStyle:
             SystemUiOverlayStyle.light, // status bar icons putih
       ),
@@ -93,11 +93,11 @@ class AppTheme {
         style: ElevatedButton.styleFrom(
           backgroundColor: MaterialStateColor.resolveWith((states) {
             if (states.contains(MaterialState.disabled)) {
-              return Colors.grey.shade400;
+              return AppColors.grey400;
             }
-            return Colors.blue.shade800; // Warna biru tua
+            return AppColors.blue800;
           }),
-          foregroundColor: Colors.white,
+          foregroundColor: AppColors.white,
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           elevation: 2,
@@ -138,7 +138,7 @@ class AppTheme {
         errorStyle: TextStyle(color: AppColors.error, fontSize: 12),
       ),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
-        backgroundColor: Colors.white,
+        backgroundColor: AppColors.white,
         selectedItemColor: AppColors.lightPrimary,
         unselectedItemColor: AppColors.lightTextSecondary,
         selectedLabelStyle: const TextStyle(fontSize: 12),
@@ -167,11 +167,11 @@ class AppTheme {
         surface: AppColors.darkSurface,
         background: AppColors.darkBackground,
         error: AppColors.error,
-        onPrimary: Colors.black, // jika kontras kurang, ganti ke Colors.white
-        onSecondary: Colors.black,
+        onPrimary: AppColors.black,
+        onSecondary: AppColors.black,
         onSurface: AppColors.darkTextPrimary,
         onBackground: AppColors.darkTextPrimary,
-        onError: Colors.black,
+        onError: AppColors.black,
         brightness: Brightness.dark,
       ),
       textTheme: TextTheme(
@@ -221,7 +221,7 @@ class AppTheme {
         ),
         iconTheme: IconThemeData(color: AppColors.darkTextPrimary, size: 24),
         systemOverlayStyle: SystemUiOverlayStyle.light.copyWith(
-          statusBarColor: Colors.transparent,
+          statusBarColor: AppColors.transparent,
           statusBarIconBrightness: Brightness.light,
           statusBarBrightness: Brightness.dark,
         ),
@@ -243,11 +243,11 @@ class AppTheme {
         style: ElevatedButton.styleFrom(
           backgroundColor: MaterialStateColor.resolveWith((states) {
             if (states.contains(MaterialState.disabled)) {
-              return Colors.grey.shade700;
+              return AppColors.grey700;
             }
-            return Colors.blueGrey.shade800; // Warna biru tua untuk dark mode
+            return AppColors.blueGrey800;
           }),
-          foregroundColor: Colors.white,
+          foregroundColor: AppColors.white,
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           elevation: 2,
@@ -322,9 +322,9 @@ class AppTheme {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
     final color = usePrimaryColor
-        ? (isDark ? const Color.fromARGB(255, 0, 0, 0) : AppColors.lightPrimary)
-              .withOpacity(opacity)
-        : (isDark ? Colors.grey[800]! : Colors.grey[200]!).withOpacity(opacity);
+        ? (isDark ? AppColors.black : AppColors.lightPrimary)
+            .withOpacity(opacity)
+        : (isDark ? AppColors.grey800 : AppColors.grey200).withOpacity(opacity);
 
     return Positioned(
       top: top,


### PR DESCRIPTION
## Summary
- add blue800, blueGrey800, grey200, grey400 to `AppColors`
- replace `Colors.*` literals in `AppTheme` with corresponding `AppColors`

## Testing
- `dart format lib/config/app_theme.dart lib/config/app_colors.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb75b88de8832bb90dc5c5f0b30b3e