### PR TITLE
Remove outdated tab keep-alive mixins

### DIFF
--- a/lib/screens/artikel/artikel_screen.dart
+++ b/lib/screens/artikel/artikel_screen.dart
@@ -17,13 +17,10 @@ class ArtikelScreen extends StatefulWidget {
 }
 
 class _ArtikelScreenState extends State<ArtikelScreen>
-    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
+    with WidgetsBindingObserver {
   final ScrollController _scrollController = ScrollController();
   bool _isMounted = false;
   List<Artikel>? _lastItems;
-
-  @override
-  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -112,7 +109,6 @@ class _ArtikelScreenState extends State<ArtikelScreen>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     final theme = Theme.of(context);
     final isDarkMode = theme.brightness == Brightness.dark;
     

--- a/lib/screens/galeri/widget/album_list.dart
+++ b/lib/screens/galeri/widget/album_list.dart
@@ -16,10 +16,7 @@ class AlbumList extends StatefulWidget {
   State<AlbumList> createState() => _AlbumListState();
 }
 
-class _AlbumListState extends State<AlbumList>
-    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
-  @override
-  bool get wantKeepAlive => true;
+class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
 
   bool _isMounted = false;
   List<AlbumModel>? _lastAlbums;
@@ -63,12 +60,12 @@ class _AlbumListState extends State<AlbumList>
     super.dispose();
   }
 
+  // Refresh once after the first build to avoid redundant reloads
   bool _isFirstBuild = true;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // Only refresh on first build or when coming back to the tab
     if (_isFirstBuild) {
       _isFirstBuild = false;
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -245,7 +242,6 @@ class _AlbumListState extends State<AlbumList>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     final albumProvider = Provider.of<AlbumProvider>(context);
     final isLoading = albumProvider.isLoadingFeatured;
     final hasError = albumProvider.hasErrorFeatured;

--- a/lib/screens/galeri/widget/video_list.dart
+++ b/lib/screens/galeri/widget/video_list.dart
@@ -17,10 +17,7 @@ class VideoList extends StatefulWidget {
   State<VideoList> createState() => _VideoListState();
 }
 
-class _VideoListState extends State<VideoList>
-    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
-  @override
-  bool get wantKeepAlive => true;
+class _VideoListState extends State<VideoList> with WidgetsBindingObserver {
 
   bool _isMounted = false;
   List<VideoModel>? _lastVideos;
@@ -113,7 +110,6 @@ class _VideoListState extends State<VideoList>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     return Consumer<VideoProvider>(
       builder: (context, videoProvider, _) {
         final isLoading = videoProvider.isLoadingRecent;

--- a/lib/screens/home/widget/artikel_list.dart
+++ b/lib/screens/home/widget/artikel_list.dart
@@ -18,9 +18,7 @@ class ArtikelList extends StatefulWidget {
 }
 
 class ArtikelListState extends State<ArtikelList>
-    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
-  @override
-  bool get wantKeepAlive => true;
+    with WidgetsBindingObserver {
 
   @override
   void initState() {
@@ -55,8 +53,6 @@ class ArtikelListState extends State<ArtikelList>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     final prov = context.watch<ArtikelProvider>();
     final bool isLoading = prov.isLoadingRecent;
     final List<Artikel> artikelList = prov.recentArtikels;

--- a/lib/screens/home/widget/event_list.dart
+++ b/lib/screens/home/widget/event_list.dart
@@ -16,9 +16,7 @@ class EventList extends StatefulWidget {
 }
 
 class _EventListState extends State<EventList>
-    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
-  @override
-  bool get wantKeepAlive => true;
+    with WidgetsBindingObserver {
 
   @override
   void initState() {
@@ -59,8 +57,6 @@ class _EventListState extends State<EventList>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     final prov = context.watch<EventProvider>();
     final isLoading = prov.isLoading;
     final events = prov.events;

--- a/lib/screens/home/widget/penyiar_list.dart
+++ b/lib/screens/home/widget/penyiar_list.dart
@@ -15,9 +15,7 @@ class PenyiarList extends StatefulWidget {
 }
 
 class _PenyiarListState extends State<PenyiarList>
-    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
-  @override
-  bool get wantKeepAlive => true;
+    with WidgetsBindingObserver {
 
   @override
   void initState() {
@@ -48,8 +46,6 @@ class _PenyiarListState extends State<PenyiarList>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     return Selector<PenyiarProvider, _PenyiarVm>(
       selector: (_, p) => _PenyiarVm(
         isLoading: p.isLoading,

--- a/lib/screens/home/widget/program_list.dart
+++ b/lib/screens/home/widget/program_list.dart
@@ -17,9 +17,7 @@ class ProgramList extends StatefulWidget {
 }
 
 class _ProgramListState extends State<ProgramList>
-    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
-  @override
-  bool get wantKeepAlive => true;
+    with WidgetsBindingObserver {
 
   @override
   void initState() {
@@ -54,8 +52,6 @@ class _ProgramListState extends State<ProgramList>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     final prov = context.watch<ProgramProvider>();
     final bool isLoading = prov.isLoadingTodays;
     final List<ProgramModel> programList = prov.todaysPrograms;


### PR DESCRIPTION
## Summary
- remove AutomaticKeepAliveClientMixin from home and gallery widgets no longer using tabs
- clarify album list refresh comment for single-screen use

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb766424c0832b9a090c5e0d2a58bc