### PR TITLE
refactor: remove hardcoded colors in key screens

### DIFF
--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -107,7 +107,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Failed to send message: $e'),
-          backgroundColor: Colors.red,
+          backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );
     }
@@ -116,7 +116,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
   void _showOnlineUsers(BuildContext context, LiveChatProvider prov) {
     showModalBottomSheet(
       context: context,
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
@@ -127,9 +127,13 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Text(
+                Text(
                   'Pengguna Online',
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black87),
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
                 ),
                 const SizedBox(height: 16),
                 Flexible(
@@ -140,19 +144,30 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                       final user = prov.onlineUsers[index];
                       return ListTile(
                         leading: CircleAvatar(
-                          backgroundColor: Colors.grey[800],
+                          backgroundColor:
+                              Theme.of(context).colorScheme.primary,
                           child: Text(
                             user.username.substring(0, 1).toUpperCase(),
-                            style: const TextStyle(color: Colors.white),
+                            style: TextStyle(
+                              color:
+                                  Theme.of(context).colorScheme.onPrimary,
+                            ),
                           ),
                         ),
                         title: Text(
                           user.username,
-                          style: const TextStyle(color: Colors.white),
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
                         ),
                         subtitle: Text(
                           'Bergabung ${prov.formatTime(user.joinTime)}',
-                          style: TextStyle(color: Colors.grey[400]),
+                          style: TextStyle(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withOpacity(0.6),
+                          ),
                         ),
                       );
                     },
@@ -264,11 +279,13 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                           vertical: 8,
                         ),
                         decoration: BoxDecoration(
-                          color: Colors.blue[800],
+                          color: Theme.of(context).colorScheme.primary,
                           borderRadius: BorderRadius.circular(20),
                           boxShadow: [
                             BoxShadow(
-                              color: Colors.black.withOpacity(0.2),
+                              color: Theme.of(context)
+                                  .shadowColor
+                                  .withOpacity(0.2),
                               blurRadius: 4,
                               offset: const Offset(0, 2),
                             ),
@@ -276,8 +293,9 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                         ),
                         child: Text(
                           '$unreadCount pesan baru',
-                          style: const TextStyle(
-                            color: Colors.white,
+                          style: TextStyle(
+                            color:
+                                Theme.of(context).colorScheme.onPrimary,
                             fontWeight: FontWeight.bold,
                           ),
                         ),

--- a/lib/screens/home/widget/program_list.dart
+++ b/lib/screens/home/widget/program_list.dart
@@ -84,11 +84,14 @@ class _ProgramListState extends State<ProgramList>
             title: 'Program Hari Ini',
             onSeeAll: () => _openAll(context),
           ),
-          const Padding(
-            padding: EdgeInsets.all(16.0),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
             child: Text(
               'Tidak ada program untuk hari ini',
-              style: TextStyle(color: Colors.white70),
+              style: TextStyle(
+                color:
+                    Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+              ),
             ),
           ),
         ],
@@ -142,7 +145,7 @@ class _ProgramListState extends State<ProgramList>
                         ClipRRect(
                           borderRadius: BorderRadius.circular(6),
                           child: url.isEmpty
-                              ? _buildPlaceholderImage()
+                              ? _buildPlaceholderImage(context)
                               : CachedNetworkImage(
                                   imageUrl: url,
                                   height: 200,
@@ -150,7 +153,7 @@ class _ProgramListState extends State<ProgramList>
                                   fit: BoxFit.cover,
                                   placeholder: (_, __) => _buildLoadingThumb(),
                                   errorWidget: (_, __, ___) =>
-                                      _buildPlaceholderImage(),
+                                      _buildPlaceholderImage(context),
                                 ),
                         ),
                         const SizedBox(height: 8),
@@ -158,10 +161,10 @@ class _ProgramListState extends State<ProgramList>
                           program.namaProgram,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w700,
-                            color: Colors.white,
+                            color: Theme.of(context).colorScheme.onSurface,
                           ),
                         ),
                       ],
@@ -182,13 +185,17 @@ class _ProgramListState extends State<ProgramList>
     );
   }
 
-  Widget _buildPlaceholderImage() {
+  Widget _buildPlaceholderImage(BuildContext context) {
     return Container(
       height: 225,
       width: 160,
-      color: Colors.grey[900],
+      color: Theme.of(context).colorScheme.surface,
       alignment: Alignment.center,
-      child: const Icon(Icons.image, size: 44, color: Colors.white38),
+      child: Icon(
+        Icons.image,
+        size: 44,
+        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.38),
+      ),
     );
   }
 

--- a/lib/screens/program/program_screen.dart
+++ b/lib/screens/program/program_screen.dart
@@ -8,6 +8,7 @@ import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
 import 'package:radio_odan_app/widgets/skeleton/all_programs_skeleton.dart';
 import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 // ⬇️ Import detail screen
 import 'package:radio_odan_app/screens/program/program_detail_screen.dart';
@@ -291,7 +292,7 @@ class _AllProgramsScreenState extends State<AllProgramsScreen>
         ],
       ),
       child: Material(
-        color: Colors.transparent,
+        color: AppColors.transparent,
         child: InkWell(
           onTap: () {
             // 1) set selected di provider (hemat fetch kalau detail butuh data)
@@ -336,7 +337,8 @@ class _AllProgramsScreenState extends State<AllProgramsScreen>
                 ),
                 const SizedBox(width: 16),
                 Expanded(child: _ProgramTexts(program: program)),
-                const Icon(Icons.chevron_right, color: Colors.white, size: 24),
+                Icon(Icons.chevron_right,
+                    color: Theme.of(context).colorScheme.onSurface, size: 24),
               ],
             ),
           ),
@@ -374,10 +376,10 @@ class _ProgramTexts extends StatelessWidget {
       children: [
         Text(
           program.namaProgram,
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w600,
-            color: Colors.white,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
@@ -387,12 +389,23 @@ class _ProgramTexts extends StatelessWidget {
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.schedule, size: 14, color: Colors.white70),
+              Icon(Icons.schedule,
+                  size: 14,
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withOpacity(0.7)),
               const SizedBox(width: 6),
               Flexible(
                 child: Text(
                   program.jadwal!,
-                  style: const TextStyle(fontSize: 12, color: Colors.white70),
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withOpacity(0.7),
+                  ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),


### PR DESCRIPTION
## Summary
- use theme color scheme in program list widget
- apply theme colors in live chat screen
- replace direct color constants in program screen with theme or AppColors

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7d1fab7c832b867a938c8d8c01e5