### PR TITLE
refactor: use themed colors

### DIFF
--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -81,15 +81,15 @@ class AppColors {
   static final button = _ButtonColors();
 
   // ========== Common Color Aliases ==========
-  static const Color transparent = Colors.transparent;
-  static const Color white = Colors.white;
-  static const Color black = Colors.black;
-  static const Color red = Colors.red;
-  static const Color green = Colors.green;
-  static const Color orange = Colors.orange;
-  static const Color grey = Colors.grey;
-  static const Color blueGrey = Colors.blueGrey;
-  static const Color redAccent = Colors.redAccent;
+  static const Color transparent = Color(0x00000000);
+  static const Color white = Color(0xFFFFFFFF);
+  static const Color black = Color(0xFF000000);
+  static const Color red = Color(0xFFF44336);
+  static const Color green = Color(0xFF4CAF50);
+  static const Color orange = Color(0xFFFF9800);
+  static const Color grey = Color(0xFF9E9E9E);
+  static const Color blueGrey = Color(0xFF607D8B);
+  static const Color redAccent = Color(0xFFFF5252);
   static const Color amber300 = Color(0xFFFFD54F);
   static const Color orange700 = Color(0xFFF57C00);
   static const Color blue800 = Color(0xFF1565C0);
@@ -102,6 +102,7 @@ class AppColors {
   static const Color grey700 = Color(0xFF616161);
   static const Color grey800 = Color(0xFF424242);
   static const Color grey850 = Color(0xFF303030);
+  static const Color grey900 = Color(0xFF212121);
   static const Color white24 = Color(0x3DFFFFFF);
 
   // ========== Chat Colors ==========

--- a/lib/screens/artikel/artikel_detail_screen.dart
+++ b/lib/screens/artikel/artikel_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:html/dom.dart' as dom;
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/loading/loading_widget.dart';
@@ -186,10 +187,10 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                       // Penulis & Tanggal
                       Row(
                         children: [
-                          const Icon(
+                          Icon(
                             Icons.person_outline,
                             size: 16,
-                            color: Colors.white,
+                            color: Theme.of(context).colorScheme.onSurface,
                           ),
                           const SizedBox(width: 4),
                           Text(
@@ -202,10 +203,10 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                                 ),
                           ),
                           const SizedBox(width: 16),
-                          const Icon(
+                          Icon(
                             Icons.calendar_today,
                             size: 14,
-                            color: Colors.white,
+                            color: Theme.of(context).colorScheme.onSurface,
                           ),
                           const SizedBox(width: 4),
                           Text(
@@ -232,11 +233,14 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                             fit: BoxFit.cover,
                             errorBuilder: (_, __, ___) => Container(
                               height: 200,
-                              color: Colors.grey[800],
+                              color: AppColors.grey800,
                               alignment: Alignment.center,
-                              child: const Icon(
+                              child: Icon(
                                 Icons.broken_image,
-                                color: Colors.white54,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurface
+                                    .withOpacity(0.54),
                               ),
                             ),
                           ),
@@ -249,24 +253,24 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                           data: content,
                           style: {
                             "html": Style(
-                              color: Colors.white,
+                              color: Theme.of(context).colorScheme.onSurface,
                               fontSize: FontSize(16.0),
                               lineHeight: LineHeight(1.6),
                             ),
                             "body": Style(
-                              color: Colors.white,
+                              color: Theme.of(context).colorScheme.onSurface,
                               fontSize: FontSize(16.0),
                               lineHeight: LineHeight(1.6),
                             ),
                             "p": Style(margin: Margins.only(bottom: 16)),
                             "h1": Style(
-                              color: Colors.white,
+                              color: Theme.of(context).colorScheme.onSurface,
                               fontSize: FontSize(24.0),
                               fontWeight: FontWeight.bold,
                               margin: Margins.only(top: 24, bottom: 16),
                             ),
                             "h2": Style(
-                              color: Colors.white,
+                              color: Theme.of(context).colorScheme.onSurface,
                               fontSize: FontSize(20.0),
                               fontWeight: FontWeight.bold,
                               margin: Margins.only(top: 20, bottom: 14),
@@ -304,9 +308,14 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                               },
                         )
                       else
-                        const Text(
+                        Text(
                           'Konten belum tersedia.',
-                          style: TextStyle(color: Colors.white70),
+                          style: TextStyle(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withOpacity(0.7),
+                          ),
                         ),
                       const SizedBox(height: 80),
                     ],

--- a/lib/screens/artikel/artikel_screen.dart
+++ b/lib/screens/artikel/artikel_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/models/artikel_model.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/widgets/skeleton/artikel_all_skeleton.dart';
@@ -236,7 +237,7 @@ class _ArtikelScreenState extends State<ArtikelScreen>
         ],
       ),
       child: Material(
-        color: Colors.transparent,
+        color: AppColors.transparent,
         child: InkWell(
           onTap: () {
             Navigator.of(context).push(

--- a/lib/screens/chat/widget/chat_message_item.dart
+++ b/lib/screens/chat/widget/chat_message_item.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../../models/chat_model.dart';
 import '../../../config/color_scheme_extension.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class ChatMessageItem extends StatelessWidget {
   final ChatMessage message;
@@ -80,7 +81,7 @@ class ChatMessageItem extends StatelessWidget {
                     ),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.black.withOpacity(0.05),
+                        color: AppColors.black.withOpacity(0.05),
                         blurRadius: 2,
                         offset: const Offset(0, 1),
                       ),
@@ -134,7 +135,7 @@ class _Avatar extends StatelessWidget {
 
     return CircleAvatar(
       radius: 16,
-      backgroundColor: Colors.grey[300],
+      backgroundColor: AppColors.grey300,
       child: ClipOval(
         child: hasUrl
             ? Image.network(

--- a/lib/screens/chat/widget/no_live_placeholder.dart
+++ b/lib/screens/chat/widget/no_live_placeholder.dart
@@ -13,7 +13,7 @@ class NoLivePlaceholder extends StatelessWidget {
     // Define gradient colors here since they can't be const
     final gradientColors = [
       AppColors.liveIndicator,
-      Color.lerp(AppColors.liveIndicator, Colors.white, 0.2) ??
+      Color.lerp(AppColors.liveIndicator, AppColors.white, 0.2) ??
           AppColors.liveIndicator,
     ];
     return Container(
@@ -136,7 +136,7 @@ class NoLivePlaceholder extends StatelessWidget {
                         vertical: 12,
                       ),
                       decoration: BoxDecoration(
-                        color: Colors.transparent,
+                        color: AppColors.transparent,
                         borderRadius: BorderRadius.circular(25),
                         border: Border.all(
                           color: Theme.of(context).brightness == Brightness.dark

--- a/lib/screens/chat/widget/unread_messages_label.dart
+++ b/lib/screens/chat/widget/unread_messages_label.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class UnreadMessagesLabel extends StatelessWidget {
   final int count;
@@ -18,16 +19,16 @@ class UnreadMessagesLabel extends StatelessWidget {
       child: Container(
         width: double.infinity,
         padding: const EdgeInsets.symmetric(vertical: 8),
-        color: Colors.black54,
+        color: AppColors.black.withOpacity(0.54),
         child: Center(
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             decoration: BoxDecoration(
-              color: Colors.blue[700],
+              color: AppColors.lightPrimary,
               borderRadius: BorderRadius.circular(12),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.2),
+                  color: AppColors.black.withOpacity(0.2),
                   blurRadius: 4,
                   offset: const Offset(0, 2),
                 ),
@@ -36,7 +37,7 @@ class UnreadMessagesLabel extends StatelessWidget {
             child: Text(
               label,
               style: const TextStyle(
-                color: Colors.white,
+                color: AppColors.white,
                 fontSize: 12,
                 fontWeight: FontWeight.bold,
               ),

--- a/lib/screens/galeri/album_detail_screen.dart
+++ b/lib/screens/galeri/album_detail_screen.dart
@@ -148,7 +148,7 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
         SliverAppBar(
           expandedHeight: 250.0,
           pinned: true,
-          backgroundColor: Colors.transparent,
+          backgroundColor: AppColors.transparent,
           elevation: 0,
           iconTheme: IconThemeData(color: Theme.of(context).colorScheme.onSurface),
           flexibleSpace: FlexibleSpaceBar(
@@ -186,9 +186,9 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
                         begin: Alignment.bottomCenter,
                         end: Alignment.topCenter,
                         colors: [
-                          Colors.black.withOpacity(0.65),
-                          Colors.black.withOpacity(0.15),
-                          Colors.transparent,
+                          AppColors.black.withOpacity(0.65),
+                          AppColors.black.withOpacity(0.15),
+                          AppColors.transparent,
                         ],
                         stops: const [0, .4, 1],
                       ),
@@ -208,8 +208,8 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
                     offset: Offset(1, 1),
                     blurRadius: 3.0,
                     color: Theme.of(context).brightness == Brightness.dark
-                        ? Colors.black.withOpacity(0.6)
-                        : Colors.black45,
+                        ? AppColors.black.withOpacity(0.6)
+                        : AppColors.black.withOpacity(0.45),
                   ),
                 ],
               ),

--- a/lib/screens/galeri/widget/album_list.dart
+++ b/lib/screens/galeri/widget/album_list.dart
@@ -8,6 +8,7 @@ import 'package:radio_odan_app/config/app_routes.dart';
 import 'package:radio_odan_app/widgets/skeleton/album_list_skeleton.dart';
 import 'package:radio_odan_app/widgets/common/section_title.dart';
 import 'package:radio_odan_app/screens/galeri/album_detail_screen.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class AlbumList extends StatefulWidget {
   const AlbumList({super.key});
@@ -129,10 +130,10 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                       fit: BoxFit.cover,
                       loadingBuilder: (context, child, loadingProgress) {
                         if (loadingProgress == null) return child;
-                        return Container(color: Colors.grey[300]);
+                        return Container(color: AppColors.grey300);
                       },
                       errorBuilder: (_, __, ___) => Container(
-                        color: Colors.grey[200],
+                        color: AppColors.grey200,
                         alignment: Alignment.center,
                         child: const Icon(Icons.broken_image, size: 32),
                       ),
@@ -146,9 +147,9 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                             begin: Alignment.bottomCenter,
                             end: Alignment.topCenter,
                             colors: [
-                              Colors.black.withOpacity(0.7),
-                              Colors.transparent,
-                              Colors.transparent,
+                              AppColors.black.withOpacity(0.7),
+                              AppColors.transparent,
+                              AppColors.transparent,
                             ],
                             stops: const [0.0, 0.4, 1.0],
                           ),
@@ -166,21 +167,21 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                           vertical: 2,
                         ),
                         decoration: BoxDecoration(
-                          color: Colors.black.withOpacity(0.55),
+                          color: AppColors.black.withOpacity(0.55),
                           borderRadius: BorderRadius.circular(999),
                         ),
                         child: Row(
                           children: [
-                            const Icon(
+                            Icon(
                               Icons.photo_library_outlined,
                               size: 14,
-                              color: Colors.white,
+                              color: Theme.of(context).colorScheme.onSurface,
                             ),
                             const SizedBox(width: 2),
                             Text(
                               '${album.photosCount ?? 0}',
-                              style: const TextStyle(
-                                color: Colors.white,
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.onSurface,
                                 fontSize: 12,
                                 fontWeight: FontWeight.w600,
                               ),
@@ -194,7 +195,7 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                     Positioned.fill(
                       child: Hero(
                         tag: 'album-${album.slug}',
-                        child: Container(color: Colors.transparent),
+                        child: Container(color: AppColors.transparent),
                       ),
                     ),
                   ],
@@ -211,8 +212,8 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                   // Title
                   Text(
                     album.name,
-                    style: const TextStyle(
-                      color: Colors.white,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurface,
                       fontWeight: FontWeight.w600,
                       fontSize: 12,
                       height: 1.1,
@@ -224,7 +225,7 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                   Text(
                     '${album.photosCount ?? 0} Foto',
                     style: TextStyle(
-                      color: Colors.grey[400],
+                      color: AppColors.grey400,
                       fontSize: 10,
                       height: 1.2,
                     ),
@@ -284,10 +285,15 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                       ),
                     )
                   : items.isEmpty
-                  ? const Center(
+                  ? Center(
                       child: Text(
                         'Tidak ada album tersedia',
-                        style: TextStyle(color: Colors.white70),
+                        style: TextStyle(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withOpacity(0.7),
+                        ),
                       ),
                     )
                   : GridView.builder(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 // Config
 import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 // Providers
 import 'package:radio_odan_app/providers/program_provider.dart';
@@ -191,7 +192,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                       SliverToBoxAdapter(
                         child: Container(
                           width: double.infinity,
-                          color: Colors.transparent,
+                          color: AppColors.transparent,
                           padding: const EdgeInsets.symmetric(
                             horizontal: 16.0,
                             vertical: 12.0,

--- a/lib/screens/home/widget/artikel_list.dart
+++ b/lib/screens/home/widget/artikel_list.dart
@@ -9,6 +9,7 @@ import 'package:radio_odan_app/models/artikel_model.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/screens/artikel/artikel_screen.dart';
 import 'package:radio_odan_app/screens/artikel/artikel_detail_screen.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class ArtikelList extends StatefulWidget {
   const ArtikelList({super.key});
@@ -86,11 +87,16 @@ class ArtikelListState extends State<ArtikelList>
             title: 'Program Hari Ini',
             onSeeAll: () => _openAll(context),
           ),
-          const Padding(
-            padding: EdgeInsets.all(16.0),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
             child: Text(
               'Tidak ada program untuk hari ini',
-              style: TextStyle(color: Colors.white70),
+              style: TextStyle(
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurface
+                    .withOpacity(0.7),
+              ),
             ),
           ),
         ],
@@ -164,7 +170,7 @@ class ArtikelListState extends State<ArtikelList>
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.onSurface,
                         fontWeight: FontWeight.w500,
                       ),
                     ),
@@ -177,7 +183,11 @@ class ArtikelListState extends State<ArtikelList>
                           : '',
                       style: Theme.of(
                         context,
-                      ).textTheme.bodySmall?.copyWith(color: Colors.white70),
+                      ).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withOpacity(0.7)),
                     ),
                   ],
                 ),
@@ -199,9 +209,13 @@ class ArtikelListState extends State<ArtikelList>
     return Container(
       height: 225,
       width: 160,
-      color: Colors.grey[900],
+      color: AppColors.grey900,
       alignment: Alignment.center,
-      child: const Icon(Icons.image, size: 44, color: Colors.white38),
+      child: Icon(
+        Icons.image,
+        size: 44,
+        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.38),
+      ),
     );
   }
 

--- a/lib/screens/home/widget/event_list.dart
+++ b/lib/screens/home/widget/event_list.dart
@@ -7,6 +7,7 @@ import 'package:radio_odan_app/widgets/skeleton/event_skeleton.dart';
 import 'package:radio_odan_app/providers/event_provider.dart';
 import 'package:radio_odan_app/screens/event/event_screen.dart';
 import 'package:radio_odan_app/screens/event/event_detail_screen.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class EventList extends StatefulWidget {
   const EventList({super.key});
@@ -71,7 +72,7 @@ class _EventListState extends State<EventList>
             padding: const EdgeInsets.all(16.0),
             child: Column(
               children: [
-                const Icon(Icons.error_outline, color: Colors.red, size: 48),
+                Icon(Icons.error_outline, color: Theme.of(context).colorScheme.error, size: 48),
                 const SizedBox(height: 12),
                 Text(
                   'Gagal memuat data event',
@@ -81,7 +82,12 @@ class _EventListState extends State<EventList>
                 Text(
                   error,
                   textAlign: TextAlign.center,
-                  style: const TextStyle(color: Colors.white70),
+                  style: TextStyle(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withOpacity(0.7),
+                  ),
                 ),
                 const SizedBox(height: 12),
                 ElevatedButton(
@@ -100,11 +106,16 @@ class _EventListState extends State<EventList>
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SectionTitle(title: 'Event', onSeeAll: null),
-          const Padding(
-            padding: EdgeInsets.all(16.0),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
             child: Text(
               'Belum ada event',
-              style: TextStyle(color: Colors.white70),
+              style: TextStyle(
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurface
+                    .withOpacity(0.7),
+              ),
             ),
           ),
         ],
@@ -172,10 +183,10 @@ class _EventListState extends State<EventList>
                             e.judul,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
+                            style: TextStyle(
                               fontSize: 14,
                               fontWeight: FontWeight.w600,
-                              color: Colors.white,
+                              color: Theme.of(context).colorScheme.onSurface,
                               height: 1.2,
                             ),
                           ),
@@ -187,9 +198,12 @@ class _EventListState extends State<EventList>
                               e.formattedTanggal,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
+                              style: TextStyle(
                                 fontSize: 12,
-                                color: Colors.white70,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurface
+                                    .withOpacity(0.7),
                               ),
                             ),
                           ),
@@ -205,9 +219,14 @@ class _EventListState extends State<EventList>
   }
 
   Widget _thumbPlaceholder() => Container(
-    color: Colors.grey[900],
+    color: AppColors.grey900,
     alignment: Alignment.center,
-    child: const Icon(Icons.broken_image, size: 44, color: Colors.white38),
+    child: Icon(
+      Icons.broken_image,
+      size: 44,
+      color:
+          Theme.of(context).colorScheme.onSurface.withOpacity(0.38),
+    ),
   );
 
   Widget _thumbLoading() => const Center(

--- a/lib/screens/home/widget/penyiar_list.dart
+++ b/lib/screens/home/widget/penyiar_list.dart
@@ -6,6 +6,7 @@ import 'package:radio_odan_app/models/penyiar_model.dart';
 import 'package:radio_odan_app/providers/penyiar_provider.dart';
 import 'package:radio_odan_app/widgets/common/section_title.dart';
 import 'package:radio_odan_app/widgets/skeleton/penyiar_skeleton.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class PenyiarList extends StatefulWidget {
   const PenyiarList({super.key});
@@ -68,10 +69,15 @@ class _PenyiarListState extends State<PenyiarList>
               child: vm.isLoading && vm.items.isEmpty
                   ? const PenyiarSkeleton()
                   : vm.items.isEmpty
-                  ? const Center(
+                  ? Center(
                       child: Text(
                         'Tidak ada data penyiar',
-                        style: TextStyle(color: Colors.white70),
+                        style: TextStyle(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withOpacity(0.7),
+                        ),
                       ),
                     )
                   : ListView.builder(
@@ -98,11 +104,11 @@ class _PenyiarListState extends State<PenyiarList>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.error_outline, color: Colors.red, size: 48),
+            Icon(Icons.error_outline, color: Theme.of(context).colorScheme.error, size: 48),
             const SizedBox(height: 12),
-            const Text(
+            Text(
               'Gagal memuat data penyiar',
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
             ),
             const SizedBox(height: 12),
             ElevatedButton(onPressed: onRetry, child: const Text('Coba Lagi')),
@@ -129,9 +135,9 @@ class _PenyiarCard extends StatelessWidget {
           Container(
             width: 110,
             height: 160,
-            color: Colors.grey[900],
+            color: AppColors.grey900,
             child: penyiar.avatarUrl.isEmpty
-                ? const Icon(Icons.person, size: 50, color: Colors.grey)
+                ? Icon(Icons.person, size: 50, color: AppColors.grey)
                 : CachedNetworkImage(
                     imageUrl: penyiar.avatarUrl,
                     fit: BoxFit.cover,
@@ -143,23 +149,23 @@ class _PenyiarCard extends StatelessWidget {
                       ),
                     ),
                     errorWidget: (_, __, ___) =>
-                        const Icon(Icons.person, size: 50, color: Colors.grey),
+                        Icon(Icons.person, size: 50, color: AppColors.grey),
                   ),
           ),
           // Nama overlay
           Container(
             width: double.infinity,
             padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
-            color: Colors.black.withOpacity(0.5),
+            color: AppColors.black.withOpacity(0.5),
             child: Text(
               penyiar.name,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.center,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 13,
                 fontWeight: FontWeight.w600,
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
           ),

--- a/lib/screens/player/player_screen.dart
+++ b/lib/screens/player/player_screen.dart
@@ -176,7 +176,7 @@ class _FullPlayerState extends State<FullPlayer> {
                     child: Text(
                       'LIVE',
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: Colors.white,
+                        color: AppColors.white,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
@@ -265,7 +265,7 @@ class _FullPlayerState extends State<FullPlayer> {
                                       ? 'Added to favorites'
                                       : 'Removed from favorites',
                                   style: Theme.of(context).textTheme.bodyMedium
-                                      ?.copyWith(color: Colors.white),
+                                      ?.copyWith(color: AppColors.white),
                                 ),
                                 backgroundColor: isFavorited
                                     ? AppColors.green

--- a/lib/screens/program/program_detail_screen.dart
+++ b/lib/screens/program/program_detail_screen.dart
@@ -220,9 +220,9 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const Icon(
+                        Icon(
                           Icons.error_outline,
-                          color: Colors.red,
+                          color: Theme.of(context).colorScheme.error,
                           size: 48,
                         ),
                         const SizedBox(height: 16),

--- a/lib/widgets/image_placeholder.dart
+++ b/lib/widgets/image_placeholder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class ImagePlaceholder extends StatelessWidget {
   final IconData icon;
@@ -9,7 +10,7 @@ class ImagePlaceholder extends StatelessWidget {
     Key? key,
     this.icon = Icons.image,
     this.size = 100,
-    this.color = Colors.grey,
+    this.color = AppColors.grey,
   }) : super(key: key);
 
   @override


### PR DESCRIPTION
## Summary
- replace direct `Colors` usage with `AppColors` or theme colorScheme
- add explicit color constants and `grey900` to `AppColors`
- update widgets to rely on theme-aware colors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb88652268832bb37ff68f978ee12c