### PR TITLE
refactor: use AppColors opacity in register screen

### DIFF
--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -296,9 +296,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                     child: Container(
                       width: 300,
                       height: 300,
-                      decoration: const BoxDecoration(
+                      decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Color.fromRGBO(255, 255, 255, 0.1),
+                        color: AppColors.white.withOpacity(0.1),
                       ),
                     ),
                   ),
@@ -308,9 +308,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                     child: Container(
                       width: 400,
                       height: 400,
-                      decoration: const BoxDecoration(
+                      decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Color.fromRGBO(255, 255, 255, 0.1),
+                        color: AppColors.white.withOpacity(0.1),
                       ),
                     ),
                   ),
@@ -342,7 +342,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         'Daftar untuk melanjutkan ke Radio Odan',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: const Color.fromRGBO(255, 255, 255, 0.9),
+                          color: AppColors.white.withOpacity(0.9),
                         ),
                       ),
                       const SizedBox(height: 24),


### PR DESCRIPTION
## Summary
- replace hardcoded `Color.fromRGBO` values with `AppColors.white.withOpacity`
- remove const from `BoxDecoration` where opacity is used

## Testing
- `dart format lib/screens/auth/register_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf07e1f60832b8e24c735a16d09ba