### PR TITLE
style: enhance splash circle contrast

### DIFF
--- a/lib/screens/splash/splash_screen.dart
+++ b/lib/screens/splash/splash_screen.dart
@@ -42,7 +42,7 @@ class _SplashScreenState extends State<SplashScreen> {
                 height: 300,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: AppColors.lightBackground.withValues(alpha: 0.1),
+                  color: AppColors.white.withOpacity(0.1),
                 ),
               ),
             ),
@@ -54,7 +54,7 @@ class _SplashScreenState extends State<SplashScreen> {
                 height: 400,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: AppColors.lightBackground.withValues(alpha: 0.1),
+                  color: AppColors.white.withOpacity(0.1),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- use semi-transparent white circles on splash screen for better contrast

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf1ca540c832b8fd1fd1d0e312564