### PR TITLE
Use theme color scheme for bubble colors

### DIFF
--- a/lib/config/app_theme.dart
+++ b/lib/config/app_theme.dart
@@ -320,11 +320,14 @@ class AppTheme {
     double opacity = 0.1,
   }) {
     final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
     final color = usePrimaryColor
-        ? (isDark ? AppColors.black : AppColors.lightPrimary)
-            .withOpacity(opacity)
-        : (isDark ? AppColors.grey800 : AppColors.grey200).withOpacity(opacity);
+        ? colorScheme.primary.withOpacity(opacity)
+        : (isDark
+                ? colorScheme.surfaceVariant
+                : colorScheme.secondary)
+            .withOpacity(opacity);
 
     return Positioned(
       top: top,


### PR DESCRIPTION
## Summary
- derive bubble colors from theme colorScheme for better contrast

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf1b410d8832bb6f6108587628def