### PR TITLE
Increase decorative bubble contrast

### DIFF
--- a/lib/screens/artikel/artikel_detail_screen.dart
+++ b/lib/screens/artikel/artikel_detail_screen.dart
@@ -91,6 +91,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
         final content = artikel.content.trim();
         final isEmptyContent =
             content.isEmpty || content == '<p></p>' || content == '<div></div>';
+        final colorScheme = Theme.of(context).colorScheme;
 
         return Scaffold(
           backgroundColor: Theme.of(context).scaffoldBackgroundColor,
@@ -127,9 +128,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                             height: 200,
                             decoration: BoxDecoration(
                               shape: BoxShape.circle,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurface.withOpacity(0.05),
+                              color: colorScheme.primary.withOpacity(0.1),
                             ),
                           ),
                         ),
@@ -141,9 +140,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                             height: 150,
                             decoration: BoxDecoration(
                               shape: BoxShape.circle,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurface.withOpacity(0.05),
+                              color: colorScheme.secondary.withOpacity(0.1),
                             ),
                           ),
                         ),
@@ -155,9 +152,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                             height: 50,
                             decoration: BoxDecoration(
                               shape: BoxShape.circle,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurface.withOpacity(0.05),
+                              color: colorScheme.tertiary.withOpacity(0.1),
                             ),
                           ),
                         ),

--- a/lib/screens/profile/edit_profile_screen.dart
+++ b/lib/screens/profile/edit_profile_screen.dart
@@ -135,7 +135,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 height: 200,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: colorScheme.primary.withOpacity(0.05),
+                  color: colorScheme.primary.withOpacity(0.1),
                 ),
               ),
             ),
@@ -147,7 +147,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 height: 150,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: colorScheme.tertiary.withOpacity(0.05),
+                  color: colorScheme.tertiary.withOpacity(0.1),
                 ),
               ),
             ),
@@ -159,7 +159,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 height: 80,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: colorScheme.secondary.withOpacity(0.05),
+                  color: colorScheme.secondary.withOpacity(0.1),
                 ),
               ),
             ),

--- a/lib/widgets/common/app_drawer.dart
+++ b/lib/widgets/common/app_drawer.dart
@@ -57,7 +57,7 @@ class AppDrawer extends StatelessWidget {
                   height: 200,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: colorScheme.primary.withOpacity(0.05),
+                    color: colorScheme.primary.withOpacity(0.1),
                   ),
                 ),
               ),
@@ -69,7 +69,7 @@ class AppDrawer extends StatelessWidget {
                   height: 150,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: colorScheme.tertiary.withOpacity(0.05),
+                    color: colorScheme.tertiary.withOpacity(0.1),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- enhance background bubbles on artikel and profile screens using theme colors at higher opacity for clearer contrast
- boost app drawer decorative bubble visibility with stronger theme colors

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/screens/artikel/artikel_detail_screen.dart lib/screens/profile/edit_profile_screen.dart lib/widgets/common/app_drawer.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf1e64328832ba7c81793f8792215