### PR TITLE
refactor: use theme colors in reset password screen

### DIFF
--- a/lib/screens/auth/reset_password_screen.dart
+++ b/lib/screens/auth/reset_password_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:radio_odan_app/services/auth_service.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class ResetPasswordScreen extends StatefulWidget {
   final String email; // bisa diisi otomatis dari argumen
@@ -47,24 +46,30 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
     );
     if (!mounted) return;
     setState(() => _loading = false);
+    final theme = Theme.of(context);
 
     if (err == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Password berhasil direset. Silakan login.'),
-          backgroundColor: AppColors.green,
+        SnackBar(
+          content: const Text('Password berhasil direset. Silakan login.'),
+          backgroundColor: theme.colorScheme.onPrimary,
         ),
       );
       Navigator.pushNamedAndRemoveUntil(context, AppRoutes.login, (r) => false);
     } else {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(err), backgroundColor: AppColors.red));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(err),
+          backgroundColor: theme.colorScheme.error,
+        ),
+      );
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(title: const Text('Reset Password')),
       body: Padding(
@@ -119,12 +124,12 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
                 child: ElevatedButton(
                   onPressed: _loading ? null : _submit,
                   child: _loading
-                      ? const SizedBox(
+                      ? SizedBox(
                           width: 20,
                           height: 20,
                           child: CircularProgressIndicator(
                             strokeWidth: 2,
-                            color: AppColors.white,
+                            color: theme.colorScheme.onPrimary,
                           ),
                         )
                       : const Text('Reset Password'),


### PR DESCRIPTION
## Summary
- use theme color scheme for reset password SnackBars
- rely on theme color for loading indicator

## Testing
- `dart format lib/screens/auth/reset_password_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf6dba7c0832ba46af8de9f9dc7e2