### PR TITLE
Refactor chat widget colors to use theme

### DIFF
--- a/lib/screens/chat/widget/chat_message_item.dart
+++ b/lib/screens/chat/widget/chat_message_item.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../models/chat_model.dart';
 import '../../../config/color_scheme_extension.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class ChatMessageItem extends StatelessWidget {
   final ChatMessage message;
@@ -81,7 +80,7 @@ class ChatMessageItem extends StatelessWidget {
                     ),
                     boxShadow: [
                       BoxShadow(
-                        color: AppColors.black.withOpacity(0.05),
+                        color: colors.shadow.withOpacity(0.05),
                         blurRadius: 2,
                         offset: const Offset(0, 1),
                       ),
@@ -133,9 +132,11 @@ class _Avatar extends StatelessWidget {
     // pakai CircleAvatar + Image.network (errorBuilder) biar fallback aman
     final hasUrl = url != null && url!.isNotEmpty;
 
+    final colors = Theme.of(context).colorScheme;
+
     return CircleAvatar(
       radius: 16,
-      backgroundColor: AppColors.grey300,
+      backgroundColor: colors.surfaceVariant,
       child: ClipOval(
         child: hasUrl
             ? Image.network(

--- a/lib/screens/chat/widget/message_input_field.dart
+++ b/lib/screens/chat/widget/message_input_field.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class MessageInputField extends StatelessWidget {
   final TextEditingController controller;
@@ -13,25 +12,27 @@ class MessageInputField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return SafeArea(
       top: false,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        color: AppColors.chatBackground,
+        color: colors.background,
         child: Row(
           children: [
             Expanded(
               child: TextField(
                 controller: controller,
-                style: const TextStyle(color: AppColors.white),
-                cursorColor: AppColors.white,
+                style: TextStyle(color: colors.onBackground),
+                cursorColor: colors.primary,
                 maxLines: null,
                 minLines: 1,
                 decoration: InputDecoration(
                   hintText: 'Ketik pesan...',
-                  hintStyle: const TextStyle(color: AppColors.chatHintText),
+                  hintStyle: TextStyle(color: colors.onSurfaceVariant),
                   filled: true,
-                  fillColor: AppColors.chatInputBackground,
+                  fillColor: colors.surfaceVariant,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(24),
                     borderSide: BorderSide.none,
@@ -47,10 +48,10 @@ class MessageInputField extends StatelessWidget {
             ),
             const SizedBox(width: 8),
             IconButton(
-              icon: const Icon(Icons.send, color: AppColors.white, size: 20),
+              icon: Icon(Icons.send, color: colors.onPrimary, size: 20),
               padding: const EdgeInsets.all(12),
               style: IconButton.styleFrom(
-                backgroundColor: AppColors.lightPrimary,
+                backgroundColor: colors.primary,
                 shape: const CircleBorder(),
               ),
               onPressed: onSend,

--- a/lib/screens/chat/widget/no_live_placeholder.dart
+++ b/lib/screens/chat/widget/no_live_placeholder.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class NoLivePlaceholder extends StatelessWidget {
   final VoidCallback? onNotify;
@@ -10,14 +8,14 @@ class NoLivePlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
     // Define gradient colors here since they can't be const
     final gradientColors = [
-      AppColors.liveIndicator,
-      Color.lerp(AppColors.liveIndicator, AppColors.white, 0.2) ??
-          AppColors.liveIndicator,
+      colors.error,
+      Color.lerp(colors.error, colors.onError, 0.2) ?? colors.error,
     ];
     return Container(
-      color: AppColors.chatBackground,
+      color: colors.background,
       child: Center(
         child: Padding(
           padding: const EdgeInsets.all(24.0),
@@ -39,27 +37,27 @@ class NoLivePlaceholder extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(20),
                   decoration: BoxDecoration(
-                    color: AppColors.lightCardSurface.withOpacity(0.7),
+                    color: colors.surface.withOpacity(0.7),
                     shape: BoxShape.circle,
                     border: Border.all(
-                      color: AppColors.liveIndicator.withOpacity(0.3),
+                      color: colors.error.withOpacity(0.3),
                       width: 2,
                     ),
                   ),
                   child: Icon(
                     Icons.radio_outlined,
                     size: 64,
-                    color: AppColors.liveIndicator.withOpacity(0.8),
+                    color: colors.error.withOpacity(0.8),
                   ),
                 ),
               ),
               const SizedBox(height: 24),
 
               // Judul
-              const Text(
+              Text(
                 'Tidak Ada Siaran Saat Ini',
                 style: TextStyle(
-                  color: AppColors.white,
+                  color: colors.onBackground,
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
                   letterSpacing: 0.5,
@@ -70,7 +68,7 @@ class NoLivePlaceholder extends StatelessWidget {
               Text(
                 'Siaran belum dimulai atau sedang dalam jeda.\nNantikan siaran berikutnya!',
                 style: TextStyle(
-                  color: AppColors.lightTextSecondary,
+                  color: colors.onSurfaceVariant,
                   fontSize: 14,
                   height: 1.5,
                 ),
@@ -99,25 +97,25 @@ class NoLivePlaceholder extends StatelessWidget {
                         borderRadius: BorderRadius.circular(25),
                         boxShadow: [
                           BoxShadow(
-                            color: AppColors.liveIndicator.withOpacity(0.3),
+                            color: colors.error.withOpacity(0.3),
                             blurRadius: 10,
                             offset: const Offset(0, 4),
                           ),
                         ],
                       ),
-                      child: const Row(
+                      child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Icon(
                             Icons.notifications_active_outlined,
-                            color: AppColors.white,
+                            color: colors.onError,
                             size: 18,
                           ),
-                          SizedBox(width: 8),
+                          const SizedBox(width: 8),
                           Text(
                             'Aktifkan Notifikasi',
                             style: TextStyle(
-                              color: AppColors.white,
+                              color: colors.onError,
                               fontWeight: FontWeight.w600,
                               fontSize: 14,
                             ),
@@ -136,28 +134,26 @@ class NoLivePlaceholder extends StatelessWidget {
                         vertical: 12,
                       ),
                       decoration: BoxDecoration(
-                        color: AppColors.transparent,
+                        color: Colors.transparent,
                         borderRadius: BorderRadius.circular(25),
                         border: Border.all(
-                          color: Theme.of(context).brightness == Brightness.dark
-                              ? AppColors.darkBorder
-                              : AppColors.lightBorder,
+                          color: colors.outline,
                           width: 1.5,
                         ),
                       ),
-                      child: const Row(
+                      child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Icon(
                             Icons.arrow_back_rounded,
-                            color: AppColors.white,
+                            color: colors.onBackground,
                             size: 16,
                           ),
-                          SizedBox(width: 8),
+                          const SizedBox(width: 8),
                           Text(
                             'Kembali ke Beranda',
                             style: TextStyle(
-                              color: AppColors.white,
+                              color: colors.onBackground,
                               fontWeight: FontWeight.w500,
                               fontSize: 14,
                             ),

--- a/lib/screens/chat/widget/unread_messages_label.dart
+++ b/lib/screens/chat/widget/unread_messages_label.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class UnreadMessagesLabel extends StatelessWidget {
   final int count;
@@ -13,22 +12,24 @@ class UnreadMessagesLabel extends StatelessWidget {
         ? '1 pesan belum dibaca'
         : '$count pesan belum dibaca';
 
+    final colors = Theme.of(context).colorScheme;
+
     return AnimatedOpacity(
       opacity: 1,
       duration: const Duration(milliseconds: 300),
       child: Container(
         width: double.infinity,
         padding: const EdgeInsets.symmetric(vertical: 8),
-        color: AppColors.black.withOpacity(0.54),
+        color: colors.onBackground.withOpacity(0.54),
         child: Center(
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             decoration: BoxDecoration(
-              color: AppColors.lightPrimary,
+              color: colors.primary,
               borderRadius: BorderRadius.circular(12),
               boxShadow: [
                 BoxShadow(
-                  color: AppColors.black.withOpacity(0.2),
+                  color: colors.shadow.withOpacity(0.2),
                   blurRadius: 4,
                   offset: const Offset(0, 2),
                 ),
@@ -36,8 +37,8 @@ class UnreadMessagesLabel extends StatelessWidget {
             ),
             child: Text(
               label,
-              style: const TextStyle(
-                color: AppColors.white,
+              style: TextStyle(
+                color: colors.onPrimary,
                 fontSize: 12,
                 fontWeight: FontWeight.bold,
               ),


### PR DESCRIPTION
## Summary
- replace hardcoded chat colors with ColorScheme values
- style live placeholder, input field and icons with theme-aware colors
- adjust unread message label to follow app theme

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found: flutter)*
- `dart format lib/screens/chat/widget/*.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf7065088832b925607c04ece315e