### PR TITLE
Use theme colors for auth screens

### DIFF
--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -53,14 +53,15 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     return Scaffold(
       appBar: AppBar(title: const Text('Lupa Password')),
       body: Container(
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           gradient: LinearGradient(
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
-            colors: [AppColors.lightPrimary, AppColors.lightBackground],
+            colors: [colorScheme.primary, colorScheme.background],
           ),
         ),
         child: Center(
@@ -113,16 +114,16 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                           height: 48,
                           child: ElevatedButton(
                             onPressed: _loading ? null : _submit,
-                            child: _loading
-                                ? const SizedBox(
-                                    width: 20,
-                                    height: 20,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                      color: AppColors.white,
-                                    ),
-                                  )
-                                : const Text('Kirim Link Reset'),
+                              child: _loading
+                                  ? SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: colorScheme.onPrimary,
+                                      ),
+                                    )
+                                  : const Text('Kirim Link Reset'),
                           ),
                         ),
 

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -281,11 +281,11 @@ class _RegisterScreenState extends State<RegisterScreen> {
           // Background gradient + circle waves
           Positioned.fill(
             child: Container(
-              decoration: const BoxDecoration(
+              decoration: BoxDecoration(
                 gradient: LinearGradient(
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
-                  colors: [AppColors.lightPrimary, AppColors.lightBackground],
+                  colors: [colorScheme.primary, colorScheme.background],
                 ),
               ),
               child: Stack(
@@ -298,7 +298,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       height: 300,
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: AppColors.white.withOpacity(0.1),
+                        color: colorScheme.onPrimary.withOpacity(0.1),
                       ),
                     ),
                   ),
@@ -310,7 +310,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       height: 400,
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: AppColors.white.withOpacity(0.1),
+                        color: colorScheme.onPrimary.withOpacity(0.1),
                       ),
                     ),
                   ),
@@ -333,7 +333,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         'Buat Akun Baru',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.headlineSmall?.copyWith(
-                          color: AppColors.white,
+                          color: colorScheme.onPrimary,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
@@ -342,7 +342,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         'Daftar untuk melanjutkan ke Radio Odan',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: AppColors.white.withOpacity(0.9),
+                          color: colorScheme.onPrimary.withOpacity(0.9),
                         ),
                       ),
                       const SizedBox(height: 24),
@@ -350,7 +350,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       // Name
                       TextFormField(
                         controller: _nameC,
-                        style: const TextStyle(color: AppColors.white),
+                        style: TextStyle(color: colorScheme.onPrimary),
                         decoration: _inputDecoration(
                           context,
                           label: 'Nama Lengkap',
@@ -365,7 +365,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       TextFormField(
                         controller: _emailC,
                         keyboardType: TextInputType.emailAddress,
-                        style: const TextStyle(color: AppColors.white),
+                        style: TextStyle(color: colorScheme.onPrimary),
                         decoration: _inputDecoration(
                           context,
                           label: 'Email',
@@ -380,7 +380,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       TextFormField(
                         controller: _passC,
                         obscureText: _obscure,
-                        style: const TextStyle(color: AppColors.white),
+                        style: TextStyle(color: colorScheme.onPrimary),
                         decoration: _inputDecoration(
                           context,
                           label: 'Password',
@@ -422,7 +422,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       TextFormField(
                         controller: _confirmC,
                         obscureText: _obscure,
-                        style: const TextStyle(color: AppColors.white),
+                        style: TextStyle(color: colorScheme.onPrimary),
                         decoration: _inputDecoration(
                           context,
                           label: 'Konfirmasi Password',
@@ -444,8 +444,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                       setState(() => _agreeTerms = v ?? false),
                             fillColor: WidgetStateProperty.resolveWith<Color>(
                               (states) => states.contains(WidgetState.selected)
-                                  ? AppColors.white
-                                  : AppColors.transparent,
+                                  ? colorScheme.onPrimary
+                                  : Colors.transparent,
                             ),
                             side: BorderSide(
                               color: colorScheme.onSurface.withOpacity(0.7),
@@ -462,10 +462,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                         color: colorScheme.onSurface
                                             .withOpacity(0.7)),
                                   ),
-                                  const TextSpan(
+                                  TextSpan(
                                     text: 'Syarat & Ketentuan',
                                     style: TextStyle(
-                                      color: AppColors.white,
+                                      color: colorScheme.onPrimary,
                                       fontWeight: FontWeight.bold,
                                       decoration: TextDecoration.underline,
                                     ),
@@ -476,10 +476,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                         color: colorScheme.onSurface
                                             .withOpacity(0.7)),
                                   ),
-                                  const TextSpan(
+                                  TextSpan(
                                     text: 'Kebijakan Privasi',
                                     style: TextStyle(
-                                      color: AppColors.white,
+                                      color: colorScheme.onPrimary,
                                       fontWeight: FontWeight.bold,
                                       decoration: TextDecoration.underline,
                                     ),
@@ -496,8 +496,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ElevatedButton(
                         onPressed: loading ? null : _register,
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.white,
-                          foregroundColor: AppColors.lightPrimary,
+                          backgroundColor: colorScheme.onPrimary,
+                          foregroundColor: colorScheme.primary,
                           padding: const EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12),
@@ -505,13 +505,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
                           elevation: 2,
                         ),
                         child: loading
-                            ? const SizedBox(
+                            ? SizedBox(
                                 width: 20,
                                 height: 20,
                                 child: CircularProgressIndicator(
                                   strokeWidth: 2,
                                   valueColor: AlwaysStoppedAnimation<Color>(
-                                    AppColors.lightPrimary,
+                                    colorScheme.primary,
                                   ),
                                 ),
                               )
@@ -560,10 +560,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                           width: 24,
                           height: 24,
                         ),
-                        label: const Text(
+                        label: Text(
                           'Google',
                           style: TextStyle(
-                            color: AppColors.white,
+                            color: colorScheme.onPrimary,
                             fontWeight: FontWeight.w500,
                           ),
                         ),
@@ -601,10 +601,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                               minimumSize: Size.zero,
                               tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                             ),
-                            child: const Text(
+                            child: Text(
                               'Masuk di sini',
                               style: TextStyle(
-                                color: AppColors.white,
+                                color: colorScheme.onPrimary,
                                 fontWeight: FontWeight.bold,
                                 decoration: TextDecoration.underline,
                               ),
@@ -622,10 +622,11 @@ class _RegisterScreenState extends State<RegisterScreen> {
           // Loading overlay
           if (loading)
             Container(
-              color: AppColors.black.withOpacity(0.26),
-              child: const Center(
+              color: colorScheme.onBackground.withOpacity(0.26),
+              child: Center(
                 child: CircularProgressIndicator(
-                  valueColor: AlwaysStoppedAnimation<Color>(AppColors.white),
+                  valueColor:
+                      AlwaysStoppedAnimation<Color>(colorScheme.onPrimary),
                 ),
               ),
             ),

--- a/lib/screens/auth/verification_screen.dart
+++ b/lib/screens/auth/verification_screen.dart
@@ -141,31 +141,29 @@ class _VerificationScreenState extends State<VerificationScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
 
     if (_initialLoading) {
-      return const Scaffold(
-        backgroundColor: AppColors.lightPrimary,
-        body: Center(child: CircularProgressIndicator(color: AppColors.white)),
+      return Scaffold(
+        backgroundColor: colorScheme.primary,
+        body: Center(
+          child: CircularProgressIndicator(color: colorScheme.onPrimary),
+        ),
       );
     }
 
     return Scaffold(
-      backgroundColor: AppColors.lightPrimary,
+      backgroundColor: colorScheme.primary,
       body: Stack(
         children: [
           // Background gradient
           Positioned.fill(
-            child: Builder(
-              builder: (context) => Container(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      Theme.of(context).colorScheme.background,
-                      Theme.of(context).colorScheme.surface,
-                    ],
-                  ),
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [colorScheme.primary, colorScheme.background],
                 ),
               ),
             ),
@@ -183,7 +181,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                       'Verifikasi Email',
                       textAlign: TextAlign.center,
                       style: theme.textTheme.headlineMedium?.copyWith(
-                        color: AppColors.lightTextPrimary,
+                        color: colorScheme.onPrimary,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
@@ -192,25 +190,25 @@ class _VerificationScreenState extends State<VerificationScreen> {
                     Container(
                       padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
-                        color: AppColors.white.withOpacity(0.1),
+                        color: colorScheme.onPrimary.withOpacity(0.1),
                         borderRadius: BorderRadius.circular(16),
                         border: Border.all(
-                          color: AppColors.white.withOpacity(0.2),
+                          color: colorScheme.onPrimary.withOpacity(0.2),
                           width: 1,
                         ),
                       ),
                       child: Column(
                         children: [
-                          const Icon(
+                          Icon(
                             Icons.mark_email_read_outlined,
                             size: 64,
-                            color: AppColors.lightTextPrimary,
+                            color: colorScheme.onBackground,
                           ),
                           const SizedBox(height: 16),
                           Text(
                             'Periksa Email Anda',
                             style: theme.textTheme.titleLarge?.copyWith(
-                              color: AppColors.lightTextPrimary,
+                              color: colorScheme.onBackground,
                               fontWeight: FontWeight.bold,
                             ),
                             textAlign: TextAlign.center,
@@ -219,7 +217,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                           Text(
                             'Kami telah mengirimkan link verifikasi ke:',
                             style: theme.textTheme.bodyMedium?.copyWith(
-                              color: AppColors.lightTextSecondary,
+                              color: colorScheme.onBackground.withOpacity(0.7),
                             ),
                             textAlign: TextAlign.center,
                           ),
@@ -227,7 +225,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                           Text(
                             widget.email,
                             style: theme.textTheme.bodyLarge?.copyWith(
-                              color: AppColors.lightTextPrimary,
+                              color: colorScheme.onBackground,
                               fontWeight: FontWeight.bold,
                             ),
                             textAlign: TextAlign.center,
@@ -236,7 +234,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                           Text(
                             'Klik link verifikasi di email Anda, lalu kembali ke aplikasi dan tekan "Cek status".',
                             style: theme.textTheme.bodyMedium?.copyWith(
-                              color: AppColors.lightTextSecondary,
+                              color: colorScheme.onBackground.withOpacity(0.7),
                             ),
                             textAlign: TextAlign.center,
                           ),
@@ -252,20 +250,22 @@ class _VerificationScreenState extends State<VerificationScreen> {
                       child: OutlinedButton(
                         onPressed: (_canResend && !_resending) ? _resend : null,
                         style: OutlinedButton.styleFrom(
+                          foregroundColor: colorScheme.onPrimary,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12),
                           ),
-                          side: const BorderSide(
-                            color: AppColors.lightTextPrimary,
+                          side: BorderSide(
+                            color: colorScheme.onPrimary,
                             width: 1.5,
                           ),
                         ),
                         child: _resending
-                            ? const SizedBox(
+                            ? SizedBox(
                                 width: 24,
                                 height: 24,
                                 child: CircularProgressIndicator(
                                   strokeWidth: 2,
+                                  color: colorScheme.onPrimary,
                                 ),
                               )
                             : Text(
@@ -283,12 +283,12 @@ class _VerificationScreenState extends State<VerificationScreen> {
                       child: ElevatedButton.icon(
                         onPressed: _checking ? null : _checkStatus,
                         icon: _checking
-                            ? const SizedBox(
+                            ? SizedBox(
                                 width: 18,
                                 height: 18,
                                 child: CircularProgressIndicator(
                                   strokeWidth: 2,
-                                  color: AppColors.white,
+                                  color: colorScheme.onPrimary,
                                 ),
                               )
                             : const Icon(Icons.verified),
@@ -305,11 +305,11 @@ class _VerificationScreenState extends State<VerificationScreen> {
 
                     TextButton(
                       onPressed: _goLogin,
-                      child: const Text(
+                      child: Text(
                         'Kembali ke Halaman Login',
                         style: TextStyle(
                           fontSize: 16,
-                          color: AppColors.lightTextPrimary,
+                          color: colorScheme.onPrimary,
                           decoration: TextDecoration.underline,
                         ),
                       ),


### PR DESCRIPTION
## Summary
- Align auth screens with app color scheme by using `theme.colorScheme` for gradients and text
- Update verification view and forgot password flow to rely on theme colors

## Testing
- `flutter format lib/screens/auth/register_screen.dart lib/screens/auth/forgot_password_screen.dart lib/screens/auth/verification_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf6ef7f04832b9fa351b0a483c86a