### PR TITLE
Use theme colors for chat input field

### DIFF
--- a/lib/screens/chat/widget/message_input_field.dart
+++ b/lib/screens/chat/widget/message_input_field.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class MessageInputField extends StatelessWidget {
   final TextEditingController controller;
@@ -31,9 +30,9 @@ class MessageInputField extends StatelessWidget {
                 minLines: 1,
                 decoration: InputDecoration(
                   hintText: 'Ketik pesan...',
-                  hintStyle: const TextStyle(color: AppColors.chatHintText),
+                  hintStyle: TextStyle(color: theme.colorScheme.onSurfaceVariant),
                   filled: true,
-                  fillColor: AppColors.chatInputBackground,
+                  fillColor: theme.colorScheme.surfaceVariant,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(24),
                     borderSide: BorderSide.none,


### PR DESCRIPTION
## Summary
- style chat message input with theme color scheme
- ensure cursor and send icon use onSurface color

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8c915c0832b9c11a1e6ee00f545