### PR TITLE
Use theme colors for placeholders

### DIFF
--- a/lib/screens/home/widget/artikel_list.dart
+++ b/lib/screens/home/widget/artikel_list.dart
@@ -9,7 +9,6 @@ import 'package:radio_odan_app/models/artikel_model.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/screens/artikel/artikel_screen.dart';
 import 'package:radio_odan_app/screens/artikel/artikel_detail_screen.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class ArtikelList extends StatefulWidget {
   const ArtikelList({super.key});
@@ -206,15 +205,16 @@ class ArtikelListState extends State<ArtikelList>
   }
 
   Widget _buildPlaceholderImage() {
+    final theme = Theme.of(context);
     return Container(
       height: 225,
       width: 160,
-      color: AppColors.grey900,
+      color: theme.colorScheme.surface,
       alignment: Alignment.center,
       child: Icon(
         Icons.image,
         size: 44,
-        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.38),
+        color: theme.colorScheme.onSurface.withOpacity(0.38),
       ),
     );
   }

--- a/lib/screens/home/widget/event_list.dart
+++ b/lib/screens/home/widget/event_list.dart
@@ -7,7 +7,6 @@ import 'package:radio_odan_app/widgets/skeleton/event_skeleton.dart';
 import 'package:radio_odan_app/providers/event_provider.dart';
 import 'package:radio_odan_app/screens/event/event_screen.dart';
 import 'package:radio_odan_app/screens/event/event_detail_screen.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class EventList extends StatefulWidget {
   const EventList({super.key});
@@ -218,16 +217,18 @@ class _EventListState extends State<EventList>
     );
   }
 
-  Widget _thumbPlaceholder() => Container(
-    color: AppColors.grey900,
-    alignment: Alignment.center,
-    child: Icon(
-      Icons.broken_image,
-      size: 44,
-      color:
-          Theme.of(context).colorScheme.onSurface.withOpacity(0.38),
-    ),
-  );
+  Widget _thumbPlaceholder() {
+    final theme = Theme.of(context);
+    return Container(
+      color: theme.colorScheme.surface,
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.broken_image,
+        size: 44,
+        color: theme.colorScheme.onSurface.withOpacity(0.38),
+      ),
+    );
+  }
 
   Widget _thumbLoading() => const Center(
     child: SizedBox(

--- a/lib/screens/home/widget/penyiar_list.dart
+++ b/lib/screens/home/widget/penyiar_list.dart
@@ -125,6 +125,7 @@ class _PenyiarCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Container(
       width: 110,
       margin: const EdgeInsets.only(right: 12),
@@ -135,9 +136,13 @@ class _PenyiarCard extends StatelessWidget {
           Container(
             width: 110,
             height: 160,
-            color: AppColors.grey900,
+            color: theme.colorScheme.surface,
             child: penyiar.avatarUrl.isEmpty
-                ? Icon(Icons.person, size: 50, color: AppColors.grey)
+                ? Icon(
+                    Icons.person,
+                    size: 50,
+                    color: theme.colorScheme.onSurface.withOpacity(0.38),
+                  )
                 : CachedNetworkImage(
                     imageUrl: penyiar.avatarUrl,
                     fit: BoxFit.cover,
@@ -148,8 +153,11 @@ class _PenyiarCard extends StatelessWidget {
                         child: CircularProgressIndicator(strokeWidth: 2),
                       ),
                     ),
-                    errorWidget: (_, __, ___) =>
-                        Icon(Icons.person, size: 50, color: AppColors.grey),
+                    errorWidget: (_, __, ___) => Icon(
+                      Icons.person,
+                      size: 50,
+                      color: theme.colorScheme.onSurface.withOpacity(0.38),
+                    ),
                   ),
           ),
           // Nama overlay


### PR DESCRIPTION
## Summary
- Use `theme.colorScheme.surface` for placeholder backgrounds across home widgets
- Style placeholder icons with `theme.colorScheme.onSurface` and appropriate opacity

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8f0ef30832bab87fd6202a6cbd9