### PR TITLE
Use theme colors for album placeholders and badges

### DIFF
--- a/lib/screens/galeri/widget/album_list.dart
+++ b/lib/screens/galeri/widget/album_list.dart
@@ -130,10 +130,12 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                       fit: BoxFit.cover,
                       loadingBuilder: (context, child, loadingProgress) {
                         if (loadingProgress == null) return child;
-                        return Container(color: AppColors.grey300);
+                        return Container(
+                          color: Theme.of(context).colorScheme.surfaceVariant,
+                        );
                       },
                       errorBuilder: (_, __, ___) => Container(
-                        color: AppColors.grey200,
+                        color: Theme.of(context).colorScheme.surfaceVariant,
                         alignment: Alignment.center,
                         child: const Icon(Icons.broken_image, size: 32),
                       ),
@@ -167,7 +169,10 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                           vertical: 2,
                         ),
                         decoration: BoxDecoration(
-                          color: AppColors.black.withOpacity(0.55),
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withOpacity(0.55),
                           borderRadius: BorderRadius.circular(999),
                         ),
                         child: Row(
@@ -225,7 +230,8 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                   Text(
                     '${album.photosCount ?? 0} Foto',
                     style: TextStyle(
-                      color: AppColors.grey400,
+                      color:
+                          Theme.of(context).colorScheme.onSurfaceVariant,
                       fontSize: 10,
                       height: 1.2,
                     ),


### PR DESCRIPTION
## Summary
- use `Theme.of(context).colorScheme.surfaceVariant` for album image placeholders
- derive badge overlay from `colorScheme.onSurface.withOpacity(0.55)`
- show photo count using `colorScheme.onSurfaceVariant`

## Testing
- `flutter format lib/screens/galeri/widget/album_list.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9019ef8832b8b128a4b979cfcce