### PR TITLE
Use theme onPrimary color for save icon

### DIFF
--- a/lib/screens/profile/edit_profile_screen.dart
+++ b/lib/screens/profile/edit_profile_screen.dart
@@ -294,7 +294,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                                       Icon(
                                         Icons.save_alt_rounded,
                                         size: 20,
-                                        color: AppColors.button.primaryText,
+                                        color: Theme.of(context).colorScheme.onPrimary,
                                       ),
                                       const SizedBox(width: 8),
                                       const Text('Simpan Perubahan'),


### PR DESCRIPTION
## Summary
- use `Theme.of(context).colorScheme.onPrimary` for the save icon text color in edit profile

## Testing
- `dart format lib/screens/profile/edit_profile_screen.dart` *(command not found: dart)*
- `flutter analyze` *(command not found: flutter)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfb97302c832b9accd487ffbe569b