### PR TITLE
fix: use theme surface color for fallback image

### DIFF
--- a/lib/screens/artikel/artikel_detail_screen.dart
+++ b/lib/screens/artikel/artikel_detail_screen.dart
@@ -228,7 +228,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
                             fit: BoxFit.cover,
                             errorBuilder: (_, __, ___) => Container(
                               height: 200,
-                              color: AppColors.grey800,
+                              color: Theme.of(context).colorScheme.surface,
                               alignment: Alignment.center,
                               child: Icon(
                                 Icons.broken_image,


### PR DESCRIPTION
## Summary
- use `colorScheme.surface` for fallback image background

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bdfb889288832ba07b74667c4f1e13