### PR TITLE
Use theme colors in section title

### DIFF
--- a/lib/widgets/common/section_title.dart
+++ b/lib/widgets/common/section_title.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class SectionTitle extends StatelessWidget {
   final String title;
@@ -24,10 +23,10 @@ class SectionTitle extends StatelessWidget {
             title,
             style:
                 titleStyle ??
-                const TextStyle(
+                TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
-                  color: AppColors.white,
+                  color: Theme.of(context).colorScheme.onSurface,
                   letterSpacing: 0.5,
                 ),
           ),
@@ -38,7 +37,7 @@ class SectionTitle extends StatelessWidget {
                 "Lihat Semua",
                 style: TextStyle(
                   fontSize: 14,
-                  color: AppColors.amber300,
+                  color: Theme.of(context).colorScheme.primary,
                   fontWeight: FontWeight.w500,
                 ),
               ),


### PR DESCRIPTION
## Summary
- use color scheme colors for section title and link

## Testing
- ⚠️ `dart format lib/widgets/common/section_title.dart` (command not found)
- ⚠️ `flutter analyze` (command not found)
- ⚠️ `flutter test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bdfd3886f0832ba75877bdb2207412