### PR TITLE
Refine transparent color handling

### DIFF
--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -441,7 +441,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                             fillColor: WidgetStateProperty.resolveWith<Color>(
                               (states) => states.contains(WidgetState.selected)
                                   ? colorScheme.onPrimary
-                                  : Colors.transparent,
+                                  : colorScheme.surface,
                             ),
                             side: BorderSide(
                               color: colorScheme.onBackground.withOpacity(0.7),

--- a/lib/screens/chat/widget/no_live_placeholder.dart
+++ b/lib/screens/chat/widget/no_live_placeholder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 
 class NoLivePlaceholder extends StatelessWidget {
   final VoidCallback? onNotify;
@@ -128,7 +129,7 @@ class NoLivePlaceholder extends StatelessWidget {
                         vertical: 12,
                       ),
                       decoration: BoxDecoration(
-                        color: Colors.transparent,
+                        color: AppColors.transparent,
                         borderRadius: BorderRadius.circular(25),
                         border: Border.all(
                           color: colors.outline,

--- a/lib/screens/galeri/widget/album_list.dart
+++ b/lib/screens/galeri/widget/album_list.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:radio_odan_app/models/album_model.dart';
 import 'package:radio_odan_app/providers/album_provider.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/widgets/skeleton/album_list_skeleton.dart';
 import 'package:radio_odan_app/widgets/common/section_title.dart';
 import 'package:radio_odan_app/screens/galeri/album_detail_screen.dart';
@@ -152,8 +153,8 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                                   .colorScheme
                                   .onSurface
                                   .withOpacity(0.7),
-                              Colors.transparent,
-                              Colors.transparent,
+                              AppColors.transparent,
+                              AppColors.transparent,
                             ],
                             stops: const [0.0, 0.4, 1.0],
                           ),
@@ -202,7 +203,7 @@ class _AlbumListState extends State<AlbumList> with WidgetsBindingObserver {
                     Positioned.fill(
                       child: Hero(
                         tag: 'album-${album.slug}',
-                        child: Container(color: Colors.transparent),
+                        child: Container(color: AppColors.transparent),
                       ),
                     ),
                   ],

--- a/lib/screens/player/player_screen.dart
+++ b/lib/screens/player/player_screen.dart
@@ -99,7 +99,7 @@ class _FullPlayerState extends State<FullPlayer> {
           ),
         ),
         centerTitle: true,
-        backgroundColor: Colors.transparent,
+        backgroundColor: theme.colorScheme.surface,
         foregroundColor: theme.colorScheme.onSurface,
         elevation: 0,
         leading: IconButton(


### PR DESCRIPTION
## Summary
- Use AppColors.transparent for gradient overlays and hero placeholders in album list and chat placeholder
- Use theme surface color for player app bar and checkbox fill in registration

## Testing
- `dart format lib/screens/galeri/widget/album_list.dart lib/screens/player/player_screen.dart lib/screens/chat/widget/no_live_placeholder.dart lib/screens/auth/register_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfd539e84832ba0610a024112f432