### PR TITLE
Use theme color scheme for image placeholder

### DIFF
--- a/lib/widgets/image_placeholder.dart
+++ b/lib/widgets/image_placeholder.dart
@@ -1,28 +1,30 @@
 import 'package:flutter/material.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class ImagePlaceholder extends StatelessWidget {
   final IconData icon;
   final double size;
-  final Color color;
+  final Color? color;
 
   const ImagePlaceholder({
     Key? key,
     this.icon = Icons.image,
     this.size = 100,
-    this.color = AppColors.grey,
+    this.color,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final Color schemeColor =
+        color ?? Theme.of(context).colorScheme.onSurfaceVariant;
+
     return Container(
       width: size,
       height: size,
-      color: color.withOpacity(0.1),
+      color: schemeColor.withOpacity(0.1),
       child: Icon(
         icon,
         size: size * 0.5,
-        color: color.withOpacity(0.5),
+        color: schemeColor.withOpacity(0.5),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- derive placeholder colors from the theme's onSurfaceVariant color
- apply the theme-based color to container and icon with appropriate opacity

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff0d6ed8832ba95e5f88589ab7a3