### PR TITLE
Use theme color scheme for skeleton widgets

### DIFF
--- a/lib/widgets/skeleton/album_list_skeleton.dart
+++ b/lib/widgets/skeleton/album_list_skeleton.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class AlbumListSkeleton extends StatelessWidget {
   const AlbumListSkeleton({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return GridView.builder(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
@@ -19,13 +19,13 @@ class AlbumListSkeleton extends StatelessWidget {
       ),
       itemBuilder: (context, index) {
         return Shimmer.fromColors(
-          baseColor: AppColors.grey850, // dark theme base
-          highlightColor: AppColors.grey700, // shimmer highlight
+          baseColor: theme.colorScheme.surfaceVariant, // dark theme base
+          highlightColor: theme.colorScheme.surface, // shimmer highlight
           child: Container(
             margin: const EdgeInsets.only(bottom: 16),
             height: 180,
             decoration: BoxDecoration(
-              color: AppColors.grey850,
+              color: theme.colorScheme.surfaceVariant,
               borderRadius: BorderRadius.circular(12),
             ),
           ),

--- a/lib/widgets/skeleton/all_programs_skeleton.dart
+++ b/lib/widgets/skeleton/all_programs_skeleton.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class AllProgramsSkeleton extends StatelessWidget {
   final int itemCount;
@@ -9,6 +8,7 @@ class AllProgramsSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return ListView.builder(
       padding: const EdgeInsets.all(16),
       itemCount: itemCount,
@@ -20,13 +20,13 @@ class AllProgramsSkeleton extends StatelessWidget {
             children: [
               // Image placeholder
               Shimmer.fromColors(
-                baseColor: AppColors.grey850,
-                highlightColor: AppColors.grey700,
+                baseColor: theme.colorScheme.surfaceVariant,
+                highlightColor: theme.colorScheme.surface,
                 child: Container(
                   width: 120,
                   height: 80,
                   decoration: BoxDecoration(
-                    color: AppColors.grey850,
+                    color: theme.colorScheme.surfaceVariant,
                     borderRadius: BorderRadius.circular(8),
                   ),
                 ),
@@ -38,39 +38,39 @@ class AllProgramsSkeleton extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Shimmer.fromColors(
-                      baseColor: AppColors.grey850,
-                      highlightColor: AppColors.grey700,
+                      baseColor: theme.colorScheme.surfaceVariant,
+                      highlightColor: theme.colorScheme.surface,
                       child: Container(
                         width: double.infinity,
                         height: 16,
                         decoration: BoxDecoration(
-                          color: AppColors.grey850,
+                          color: theme.colorScheme.surfaceVariant,
                           borderRadius: BorderRadius.circular(4),
                         ),
                       ),
                     ),
                     const SizedBox(height: 8),
                     Shimmer.fromColors(
-                      baseColor: AppColors.grey850,
-                      highlightColor: AppColors.grey700,
+                      baseColor: theme.colorScheme.surfaceVariant,
+                      highlightColor: theme.colorScheme.surface,
                       child: Container(
                         width: 100,
                         height: 14,
                         decoration: BoxDecoration(
-                          color: AppColors.grey850,
+                          color: theme.colorScheme.surfaceVariant,
                           borderRadius: BorderRadius.circular(4),
                         ),
                       ),
                     ),
                     const SizedBox(height: 12),
                     Shimmer.fromColors(
-                      baseColor: AppColors.grey850,
-                      highlightColor: AppColors.grey700,
+                      baseColor: theme.colorScheme.surfaceVariant,
+                      highlightColor: theme.colorScheme.surface,
                       child: Container(
                         width: 60,
                         height: 12,
                         decoration: BoxDecoration(
-                          color: AppColors.grey850,
+                          color: theme.colorScheme.surfaceVariant,
                           borderRadius: BorderRadius.circular(4),
                         ),
                       ),

--- a/lib/widgets/skeleton/app_header_skeleton.dart
+++ b/lib/widgets/skeleton/app_header_skeleton.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class AppHeaderSkeleton extends StatelessWidget {
   const AppHeaderSkeleton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -32,8 +31,8 @@ class AppHeaderSkeleton extends StatelessWidget {
         ],
       ),
       child: Shimmer.fromColors(
-        baseColor: isDark ? colorScheme.surfaceVariant : AppColors.grey300,
-        highlightColor: isDark ? colorScheme.surface : AppColors.grey100,
+        baseColor: theme.colorScheme.surfaceVariant,
+        highlightColor: theme.colorScheme.surface,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -56,7 +55,7 @@ class AppHeaderSkeleton extends StatelessWidget {
                   child: Text(
                     'ODAN FM',
                     style: TextStyle(
-                      color: AppColors.transparent,
+                      color: Colors.transparent,
                       fontSize: 20,
                       fontWeight: FontWeight.w800,
                       letterSpacing: 1.2,

--- a/lib/widgets/skeleton/artikel_all_skeleton.dart
+++ b/lib/widgets/skeleton/artikel_all_skeleton.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class ArtikelAllSkeleton extends StatelessWidget {
   final int itemCount;
@@ -9,6 +8,7 @@ class ArtikelAllSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return ListView.builder(
       padding: const EdgeInsets.all(16),
       itemCount: itemCount,
@@ -20,13 +20,13 @@ class ArtikelAllSkeleton extends StatelessWidget {
             children: [
               // Thumbnail shimmer
               Shimmer.fromColors(
-                baseColor: AppColors.grey850,
-                highlightColor: AppColors.grey700,
+                baseColor: theme.colorScheme.surfaceVariant,
+                highlightColor: theme.colorScheme.surface,
                 child: Container(
                   width: 100,
                   height: 100,
                   decoration: BoxDecoration(
-                    color: AppColors.grey850,
+                    color: theme.colorScheme.surfaceVariant,
                     borderRadius: BorderRadius.circular(8),
                   ),
                 ),
@@ -39,12 +39,12 @@ class ArtikelAllSkeleton extends StatelessWidget {
                   children: [
                     // Judul shimmer
                     Shimmer.fromColors(
-                      baseColor: AppColors.grey850,
-                      highlightColor: AppColors.grey700,
+                      baseColor: theme.colorScheme.surfaceVariant,
+                      highlightColor: theme.colorScheme.surface,
                       child: Container(
                         width: double.infinity,
                         height: 16,
-                        color: AppColors.grey850,
+                        color: theme.colorScheme.surfaceVariant,
                       ),
                     ),
                     const SizedBox(height: 6),
@@ -52,22 +52,22 @@ class ArtikelAllSkeleton extends StatelessWidget {
                     Row(
                       children: [
                         Shimmer.fromColors(
-                          baseColor: AppColors.grey850,
-                          highlightColor: AppColors.grey700,
+                          baseColor: theme.colorScheme.surfaceVariant,
+                          highlightColor: theme.colorScheme.surface,
                           child: Container(
                             width: 60,
                             height: 12,
-                            color: AppColors.grey850,
+                            color: theme.colorScheme.surfaceVariant,
                           ),
                         ),
                         const SizedBox(width: 6),
                         Shimmer.fromColors(
-                          baseColor: AppColors.grey850,
-                          highlightColor: AppColors.grey700,
+                          baseColor: theme.colorScheme.surfaceVariant,
+                          highlightColor: theme.colorScheme.surface,
                           child: Container(
                             width: 40,
                             height: 12,
-                            color: AppColors.grey850,
+                            color: theme.colorScheme.surfaceVariant,
                           ),
                         ),
                       ],
@@ -75,12 +75,12 @@ class ArtikelAllSkeleton extends StatelessWidget {
                     const SizedBox(height: 4),
                     // Date shimmer
                     Shimmer.fromColors(
-                      baseColor: AppColors.grey850,
-                      highlightColor: AppColors.grey700,
+                      baseColor: theme.colorScheme.surfaceVariant,
+                      highlightColor: theme.colorScheme.surface,
                       child: Container(
                         width: 80,
                         height: 12,
-                        color: AppColors.grey850,
+                        color: theme.colorScheme.surfaceVariant,
                       ),
                     ),
                   ],

--- a/lib/widgets/skeleton/artikel_skeleton.dart
+++ b/lib/widgets/skeleton/artikel_skeleton.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class ArtikelSkeleton extends StatelessWidget {
   final int itemCount;
@@ -9,6 +8,7 @@ class ArtikelSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return SizedBox(
       height: 200,
       child: ListView.builder(
@@ -24,13 +24,13 @@ class ArtikelSkeleton extends StatelessWidget {
               children: [
                 // shimmer gambar
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     height: 150,
                     width: 160,
                     decoration: BoxDecoration(
-                      color: AppColors.grey850,
+                      color: theme.colorScheme.surfaceVariant,
                       borderRadius: BorderRadius.circular(5),
                     ),
                   ),
@@ -38,23 +38,23 @@ class ArtikelSkeleton extends StatelessWidget {
                 const SizedBox(height: 8),
                 // shimmer judul
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     width: 120,
                     height: 16,
-                    color: AppColors.grey850,
+                    color: theme.colorScheme.surfaceVariant,
                   ),
                 ),
                 const SizedBox(height: 4),
                 // shimmer tanggal
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     width: 80,
                     height: 12,
-                    color: AppColors.grey850,
+                    color: theme.colorScheme.surfaceVariant,
                   ),
                 ),
               ],

--- a/lib/widgets/skeleton/event_skeleton.dart
+++ b/lib/widgets/skeleton/event_skeleton.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
 
 class EventSkeleton extends StatelessWidget {
   const EventSkeleton({super.key});
@@ -30,11 +29,12 @@ class EventCardSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Shimmer.fromColors(
-      baseColor: AppColors.grey800,
-      highlightColor: AppColors.grey700,
+      baseColor: theme.colorScheme.surfaceVariant,
+      highlightColor: theme.colorScheme.surface,
       child: Card(
-        color: AppColors.darkSurface.withOpacity(0.9),
+        color: theme.colorScheme.surface.withOpacity(0.9),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         elevation: 2,
         child: Padding(
@@ -47,8 +47,8 @@ class EventCardSkeleton extends StatelessWidget {
                 aspectRatio: 16 / 9,
                 child: DecoratedBox(
                   decoration: BoxDecoration(
-                    color: AppColors.white24,
-                    borderRadius: BorderRadius.all(Radius.circular(8)),
+                    color: theme.colorScheme.onSurface.withOpacity(0.1),
+                    borderRadius: const BorderRadius.all(Radius.circular(8)),
                   ),
                 ),
               ),
@@ -58,7 +58,7 @@ class EventCardSkeleton extends StatelessWidget {
                 height: 20,
                 width: double.infinity,
                 decoration: BoxDecoration(
-                  color: AppColors.white24,
+                  color: theme.colorScheme.onSurface.withOpacity(0.1),
                   borderRadius: BorderRadius.circular(4),
                 ),
               ),
@@ -68,7 +68,7 @@ class EventCardSkeleton extends StatelessWidget {
                 height: 16,
                 width: 120,
                 decoration: BoxDecoration(
-                  color: AppColors.white24,
+                  color: theme.colorScheme.onSurface.withOpacity(0.1),
                   borderRadius: BorderRadius.circular(4),
                 ),
               ),

--- a/lib/widgets/skeleton/penyiar_skeleton.dart
+++ b/lib/widgets/skeleton/penyiar_skeleton.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class PenyiarSkeleton extends StatelessWidget {
   final int itemCount;
@@ -9,6 +8,7 @@ class PenyiarSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return SizedBox(
       height: 120,
       child: ListView.builder(
@@ -21,25 +21,25 @@ class PenyiarSkeleton extends StatelessWidget {
             child: Column(
               children: [
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     width: 80,
                     height: 80,
                     decoration: BoxDecoration(
-                      color: AppColors.grey850,
+                      color: theme.colorScheme.surfaceVariant,
                       shape: BoxShape.circle,
                     ),
                   ),
                 ),
                 const SizedBox(height: 6),
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     width: 60,
                     height: 14,
-                    color: AppColors.grey850,
+                    color: theme.colorScheme.surfaceVariant,
                   ),
                 ),
               ],

--- a/lib/widgets/skeleton/program_skeleton.dart
+++ b/lib/widgets/skeleton/program_skeleton.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class ProgramSkeleton extends StatelessWidget {
   final int itemCount;
@@ -9,6 +8,7 @@ class ProgramSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return SizedBox(
       height: 300, // tinggi tetap untuk skeleton
       child: ListView.builder(
@@ -26,13 +26,13 @@ class ProgramSkeleton extends StatelessWidget {
               children: [
                 // shimmer gambar
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850, // dark mode
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant, // dark mode
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     height: 225,
                     width: 160,
                     decoration: BoxDecoration(
-                      color: AppColors.grey850,
+                      color: theme.colorScheme.surfaceVariant,
                       borderRadius: BorderRadius.circular(5),
                     ),
                   ),
@@ -40,13 +40,13 @@ class ProgramSkeleton extends StatelessWidget {
                 const SizedBox(height: 8),
                 // shimmer judul program
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     width: 120,
                     height: 16,
                     decoration: BoxDecoration(
-                      color: AppColors.grey850,
+                      color: theme.colorScheme.surfaceVariant,
                       borderRadius: BorderRadius.circular(3),
                     ),
                   ),
@@ -54,13 +54,13 @@ class ProgramSkeleton extends StatelessWidget {
                 const SizedBox(height: 4),
                 // shimmer nama penyiar
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     width: 100,
                     height: 14,
                     decoration: BoxDecoration(
-                      color: AppColors.grey850,
+                      color: theme.colorScheme.surfaceVariant,
                       borderRadius: BorderRadius.circular(3),
                     ),
                   ),
@@ -68,13 +68,13 @@ class ProgramSkeleton extends StatelessWidget {
                 const SizedBox(height: 2),
                 // shimmer hari & jam
                 Shimmer.fromColors(
-                  baseColor: AppColors.grey850,
-                  highlightColor: AppColors.grey700,
+                  baseColor: theme.colorScheme.surfaceVariant,
+                  highlightColor: theme.colorScheme.surface,
                   child: Container(
                     width: 80,
                     height: 12,
                     decoration: BoxDecoration(
-                      color: AppColors.grey850,
+                      color: theme.colorScheme.surfaceVariant,
                       borderRadius: BorderRadius.circular(3),
                     ),
                   ),

--- a/lib/widgets/skeleton/video_list_skeleton.dart
+++ b/lib/widgets/skeleton/video_list_skeleton.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import '../../config/app_colors.dart';
 
 class VideoListSkeleton extends StatelessWidget {
   const VideoListSkeleton({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return ListView.separated(
       scrollDirection: Axis.horizontal,
       padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -14,8 +14,8 @@ class VideoListSkeleton extends StatelessWidget {
       separatorBuilder: (_, __) => const SizedBox(width: 16),
       itemBuilder: (context, index) {
         return Shimmer.fromColors(
-          baseColor: AppColors.grey850,
-          highlightColor: AppColors.grey700,
+          baseColor: theme.colorScheme.surfaceVariant,
+          highlightColor: theme.colorScheme.surface,
           child: SizedBox(
             width: 270,
             height: 190, // Fixed height to match the parent constraint
@@ -27,7 +27,7 @@ class VideoListSkeleton extends StatelessWidget {
                   height: 160, // Reduced height to accommodate the text
                   width: double.infinity,
                   decoration: BoxDecoration(
-                    color: AppColors.grey850,
+                    color: theme.colorScheme.surfaceVariant,
                     borderRadius: BorderRadius.circular(8),
                   ),
                 ),
@@ -36,7 +36,7 @@ class VideoListSkeleton extends StatelessWidget {
                   height: 16,
                   width: 200,
                   decoration: BoxDecoration(
-                    color: AppColors.grey850,
+                    color: theme.colorScheme.surfaceVariant,
                     borderRadius: BorderRadius.circular(4),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- replace hardcoded grey shimmer colors with `theme.colorScheme.surfaceVariant` and `surface`
- use theme-based colors for skeleton placeholders

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff158840832b88a030bbae862cbe