### PR TITLE
refactor: extract reusable splash background

### DIFF
--- a/lib/screens/splash/splash_screen.dart
+++ b/lib/screens/splash/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -26,58 +27,21 @@ class _SplashScreenState extends State<SplashScreen> {
         theme.brightness == Brightness.dark ? 'assets/logo-white.png' : 'assets/logo.png';
 
     return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [
-              theme.colorScheme.primary,
-              theme.colorScheme.background,
-            ],
+      body: Stack(
+        children: [
+          const AppBackground(),
+          Center(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(20),
+              child: Image.asset(
+                logoPath,
+                width: 150,
+                height: 150,
+                fit: BoxFit.contain,
+              ),
+            ),
           ),
-        ),
-        child: Stack(
-          children: [
-            // Wave circles background
-            Positioned(
-              top: -100,
-              right: -100,
-              child: Container(
-                width: 300,
-                height: 300,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: theme.colorScheme.onPrimary.withOpacity(0.1),
-                ),
-              ),
-            ),
-            Positioned(
-              bottom: -150,
-              left: -50,
-              child: Container(
-                width: 400,
-                height: 400,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: theme.colorScheme.onPrimary.withOpacity(0.1),
-                ),
-              ),
-            ),
-            // Center logo
-            Center(
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(20),
-                child: Image.asset(
-                  logoPath,
-                  width: 150,
-                  height: 150,
-                  fit: BoxFit.contain,
-                ),
-              ),
-            ),
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class AppBackground extends StatelessWidget {
+  const AppBackground({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bubbleOpacity = theme.brightness == Brightness.dark ? 0.05 : 0.1;
+
+    return SizedBox.expand(
+      child: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              theme.colorScheme.primary,
+              theme.colorScheme.background,
+            ],
+          ),
+        ),
+        child: Stack(
+          children: [
+            Positioned(
+              top: -100,
+              right: -100,
+              child: Container(
+                width: 300,
+                height: 300,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: theme.colorScheme.onPrimary.withOpacity(bubbleOpacity),
+                ),
+              ),
+            ),
+            Positioned(
+              bottom: -150,
+              left: -50,
+              child: Container(
+                width: 400,
+                height: 400,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: theme.colorScheme.onPrimary.withOpacity(bubbleOpacity),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `AppBackground` widget with gradient and themed bubbles
- use `AppBackground` on splash screen keeping logo above background

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f6470b8832baa94803646e9266a