### PR TITLE
feat: add app background widget

### DIFF
--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../../config/app_theme.dart';
+
+class AppBackground extends StatelessWidget {
+  const AppBackground({
+    super.key,
+    this.showTopRightBubble = true,
+    this.showBottomLeftBubble = true,
+    this.showCenterLeftBubble = true,
+  });
+
+  final bool showTopRightBubble;
+  final bool showBottomLeftBubble;
+  final bool showCenterLeftBubble;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDarkMode = theme.brightness == Brightness.dark;
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        Container(color: theme.colorScheme.background),
+        if (showTopRightBubble)
+          AppTheme.bubble(
+            context: context,
+            size: 200,
+            top: -50,
+            right: -50,
+            opacity: isDarkMode ? 0.1 : 0.03,
+            usePrimaryColor: true,
+          ),
+        if (showBottomLeftBubble)
+          AppTheme.bubble(
+            context: context,
+            size: 150,
+            bottom: -30,
+            left: -30,
+            opacity: isDarkMode ? 0.08 : 0.03,
+            usePrimaryColor: true,
+          ),
+        if (showCenterLeftBubble)
+          AppTheme.bubble(
+            context: context,
+            size: 50,
+            top: 100,
+            left: 100,
+            opacity: isDarkMode ? 0.06 : 0.02,
+            usePrimaryColor: true,
+          ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/common/common.dart
+++ b/lib/widgets/common/common.dart
@@ -1,0 +1,6 @@
+export 'app_background.dart';
+export 'app_bar.dart';
+export 'app_drawer.dart';
+export 'app_header.dart';
+export 'mini_player.dart';
+export 'section_title.dart';


### PR DESCRIPTION
## Summary
- add reusable `AppBackground` widget with optional bubble toggles
- export common widgets via new `common.dart`

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f7355cc832badb1347128a95e65