### PR TITLE
feat: add app background to reset password

### DIFF
--- a/lib/screens/auth/reset_password_screen.dart
+++ b/lib/screens/auth/reset_password_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:radio_odan_app/services/auth_service.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ResetPasswordScreen extends StatefulWidget {
   final String email; // bisa diisi otomatis dari argumen
@@ -72,12 +73,15 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Reset Password')),
-      body: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Form(
-          key: _formKey,
-          child: ListView(
-            children: [
+      body: Stack(
+        children: [
+          const AppBackground(),
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Form(
+              key: _formKey,
+              child: ListView(
+                children: [
               TextFormField(
                 controller: _tokenC,
                 decoration: const InputDecoration(
@@ -135,9 +139,11 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
                       : const Text('Reset Password'),
                 ),
               ),
-            ],
+                ],
+              ),
+            ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_colors.dart';
+
+class AppBackground extends StatelessWidget {
+  const AppBackground({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Positioned.fill(
+      child: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [theme.colorScheme.primary, theme.colorScheme.background],
+          ),
+        ),
+        child: Stack(
+          children: [
+            Positioned(
+              top: -100,
+              right: -100,
+              child: Container(
+                width: 300,
+                height: 300,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.white.withOpacity(0.1),
+                ),
+              ),
+            ),
+            Positioned(
+              bottom: -150,
+              left: -50,
+              child: Container(
+                width: 400,
+                height: 400,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.white.withOpacity(0.1),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable AppBackground widget with gradient and decorative circles
- show AppBackground behind reset password form using Stack

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68be0f6211d4832ba48e87a2ad5c2180