### PR TITLE
Refactor auth screen backgrounds with themed bubbles

### DIFF
--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:radio_odan_app/services/auth_service.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
   const ForgotPasswordScreen({super.key});
@@ -57,94 +58,115 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final isDarkMode = theme.brightness == Brightness.dark;
     return Scaffold(
       appBar: AppBar(title: const Text('Lupa Password')),
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [theme.colorScheme.primary, theme.colorScheme.background],
+      body: Stack(
+        children: [
+          Positioned.fill(
+            child: Container(
+              color: theme.colorScheme.background,
+              child: Stack(
+                children: [
+                  AppTheme.bubble(
+                    context: context,
+                    size: 200,
+                    top: -50,
+                    right: -50,
+                    opacity: isDarkMode ? 0.1 : 0.03,
+                    usePrimaryColor: true,
+                  ),
+                  AppTheme.bubble(
+                    context: context,
+                    size: 150,
+                    bottom: -30,
+                    left: -30,
+                    opacity: isDarkMode ? 0.08 : 0.03,
+                    usePrimaryColor: true,
+                  ),
+                ],
+              ),
+            ),
           ),
-        ),
-        child: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 420),
-              child: Card(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Form(
-                    key: _formKey,
-                    child: Column(
-                      children: [
-                        const SizedBox(height: 8),
-                        Text(
-                          'Atur Ulang Password',
-                          style: theme.textTheme.titleLarge,
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          'Masukkan email yang terdaftar. Kami akan mengirim link reset password.',
-                          textAlign: TextAlign.center,
-                          style: theme.textTheme.bodyMedium,
-                        ),
-                        const SizedBox(height: 16),
-
-                        TextFormField(
-                          controller: _emailC,
-                          keyboardType: TextInputType.emailAddress,
-                          decoration: const InputDecoration(
-                            labelText: 'Email',
-                            prefixIcon: Icon(Icons.email_outlined),
+          Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 420),
+                child: Card(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Form(
+                      key: _formKey,
+                      child: Column(
+                        children: [
+                          const SizedBox(height: 8),
+                          Text(
+                            'Atur Ulang Password',
+                            style: theme.textTheme.titleLarge,
                           ),
-                          validator: (v) {
-                            if (v == null || v.trim().isEmpty)
-                              return 'Email wajib diisi';
-                            if (!v.contains('@'))
-                              return 'Format email tidak valid';
-                            return null;
-                          },
-                        ),
-                        const SizedBox(height: 20),
-
-                        SizedBox(
-                          width: double.infinity,
-                          height: 48,
-                          child: ElevatedButton(
-                            onPressed: _loading ? null : _submit,
-                            child: _loading
-                                ? SizedBox(
-                                    width: 20,
-                                    height: 20,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                      color: theme.colorScheme.onPrimary,
-                                    ),
-                                  )
-                                : const Text('Kirim Link Reset'),
+                          const SizedBox(height: 6),
+                          Text(
+                            'Masukkan email yang terdaftar. Kami akan mengirim link reset password.',
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.bodyMedium,
                           ),
-                        ),
+                          const SizedBox(height: 16),
 
-                        const SizedBox(height: 12),
-                        TextButton(
-                          onPressed: _loading
-                              ? null
-                              : () => Navigator.pop(context),
-                          child: const Text('Kembali'),
-                        ),
-                      ],
+                          TextFormField(
+                            controller: _emailC,
+                            keyboardType: TextInputType.emailAddress,
+                            decoration: const InputDecoration(
+                              labelText: 'Email',
+                              prefixIcon: Icon(Icons.email_outlined),
+                            ),
+                            validator: (v) {
+                              if (v == null || v.trim().isEmpty)
+                                return 'Email wajib diisi';
+                              if (!v.contains('@'))
+                                return 'Format email tidak valid';
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 20),
+
+                          SizedBox(
+                            width: double.infinity,
+                            height: 48,
+                            child: ElevatedButton(
+                              onPressed: _loading ? null : _submit,
+                              child: _loading
+                                  ? SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: theme.colorScheme.onPrimary,
+                                      ),
+                                    )
+                                  : const Text('Kirim Link Reset'),
+                            ),
+                          ),
+
+                          const SizedBox(height: 12),
+                          TextButton(
+                            onPressed: _loading
+                                ? null
+                                : () => Navigator.pop(context),
+                            child: const Text('Kembali'),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -5,6 +5,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -171,6 +172,7 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final loading = context.watch<AuthProvider>().loading;
+    final isDarkMode = theme.brightness == Brightness.dark;
 
     return PopScope(
       canPop: false,
@@ -182,84 +184,96 @@ class _LoginScreenState extends State<LoginScreen> {
       child: Scaffold(
         body: Stack(
           children: [
-            // Background gradient
+            // Background bubbles
             Positioned.fill(
               child: Container(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      theme.colorScheme.primary,
-                      theme.colorScheme.background,
-                    ],
-                  ),
+                color: theme.colorScheme.background,
+                child: Stack(
+                  children: [
+                    AppTheme.bubble(
+                      context: context,
+                      size: 200,
+                      top: -50,
+                      right: -50,
+                      opacity: isDarkMode ? 0.1 : 0.03,
+                      usePrimaryColor: true,
+                    ),
+                    AppTheme.bubble(
+                      context: context,
+                      size: 150,
+                      bottom: -30,
+                      left: -30,
+                      opacity: isDarkMode ? 0.08 : 0.03,
+                      usePrimaryColor: true,
+                    ),
+                  ],
                 ),
-                child: SafeArea(
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        const SizedBox(height: 6),
+              ),
+            ),
+            SafeArea(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const SizedBox(height: 6),
 
-                        // Logo
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(16),
-                          child: Image.asset(
-                            'assets/logo-white.png',
-                            width: 96,
-                            height: 96,
-                            fit: BoxFit.contain,
+                    // Logo
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: Image.asset(
+                        'assets/logo-white.png',
+                        width: 96,
+                        height: 96,
+                        fit: BoxFit.contain,
+                      ),
+                    ),
+
+                    const SizedBox(height: 8),
+                    Text(
+                      'Selamat datang',
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: Theme.of(context).colorScheme.onSurface,
                           ),
-                        ),
-
-                        const SizedBox(height: 8),
-                        Text(
-                          'Selamat datang',
-                          style: Theme.of(context).textTheme.headlineSmall
-                              ?.copyWith(
-                                fontWeight: FontWeight.w700,
-                                color: Theme.of(context).colorScheme.onSurface,
-                              ),
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          'Masuk untuk melanjutkan ke Radio Odan',
-                          textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurface.withOpacity(.7),
-                              ),
-                        ),
-                        const SizedBox(height: 24),
-
-                        // Card Form
-                        Container(
-                          padding: const EdgeInsets.all(24),
-                          decoration: BoxDecoration(
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      'Masuk untuk melanjutkan ke Radio Odan',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                             color: Theme.of(context)
                                 .colorScheme
-                                .surface
-                                .withOpacity(0.92),
-                            borderRadius: BorderRadius.circular(16),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSurface
-                                    .withOpacity(0.08),
-                                blurRadius: 20,
-                                offset: const Offset(0, 10),
-                              ),
-                            ],
+                                .onSurface
+                                .withOpacity(.7),
                           ),
-                          child: Form(
-                            key: _formKey,
-                            child: Column(
-                              children: [
+                    ),
+                    const SizedBox(height: 24),
+
+                    // Card Form
+                    Container(
+                      padding: const EdgeInsets.all(24),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .surface
+                            .withOpacity(0.92),
+                        borderRadius: BorderRadius.circular(16),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withOpacity(0.08),
+                            blurRadius: 20,
+                            offset: const Offset(0, 10),
+                          ),
+                        ],
+                      ),
+                      child: Form(
+                        key: _formKey,
+                        child: Column(
+                          children: [
                                 TextFormField(
                                   controller: _emailC,
                                   style: Theme.of(context)

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -4,7 +4,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_colors.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
 
 class RegisterScreen extends StatefulWidget {
@@ -274,52 +274,36 @@ class _RegisterScreenState extends State<RegisterScreen> {
     final colorScheme = theme.colorScheme;
     final loading = context.watch<AuthProvider>().loading;
     final strength = _passwordStrength(_passC.text);
+    final isDarkMode = theme.brightness == Brightness.dark;
 
     return Scaffold(
       body: Stack(
         children: [
-          // Background gradient + circle waves
           Positioned.fill(
             child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [theme.colorScheme.primary, theme.colorScheme.background],
-                ),
-              ),
+              color: theme.colorScheme.background,
               child: Stack(
                 children: [
-                  Positioned(
-                    top: -100,
-                    right: -100,
-                    child: Container(
-                      width: 300,
-                      height: 300,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: AppColors.white.withOpacity(0.1),
-                      ),
-                    ),
+                  AppTheme.bubble(
+                    context: context,
+                    size: 200,
+                    top: -50,
+                    right: -50,
+                    opacity: isDarkMode ? 0.1 : 0.03,
+                    usePrimaryColor: true,
                   ),
-                  Positioned(
-                    bottom: -150,
-                    left: -50,
-                    child: Container(
-                      width: 400,
-                      height: 400,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: AppColors.white.withOpacity(0.1),
-                      ),
-                    ),
+                  AppTheme.bubble(
+                    context: context,
+                    size: 150,
+                    bottom: -30,
+                    left: -30,
+                    opacity: isDarkMode ? 0.08 : 0.03,
+                    usePrimaryColor: true,
                   ),
                 ],
               ),
             ),
           ),
-
-          // Content
           SafeArea(
             child: Center(
               child: SingleChildScrollView(
@@ -333,7 +317,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         'Buat Akun Baru',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.headlineSmall?.copyWith(
-                          color: colorScheme.onPrimary,
+                          color: colorScheme.onBackground,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
@@ -342,15 +326,14 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         'Daftar untuk melanjutkan ke Radio Odan',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: AppColors.white.withOpacity(0.9),
+                          color: colorScheme.onBackground.withOpacity(0.7),
                         ),
                       ),
                       const SizedBox(height: 24),
 
-                      // Name
                       TextFormField(
                         controller: _nameC,
-                        style: TextStyle(color: colorScheme.onPrimary),
+                        style: TextStyle(color: colorScheme.onBackground),
                         decoration: _inputDecoration(
                           context,
                           label: 'Nama Lengkap',
@@ -361,11 +344,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ),
                       const SizedBox(height: 16),
 
-                      // Email
                       TextFormField(
                         controller: _emailC,
                         keyboardType: TextInputType.emailAddress,
-                        style: TextStyle(color: colorScheme.onPrimary),
+                        style: TextStyle(color: colorScheme.onBackground),
                         decoration: _inputDecoration(
                           context,
                           label: 'Email',
@@ -376,11 +358,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ),
                       const SizedBox(height: 16),
 
-                      // Password
                       TextFormField(
                         controller: _passC,
                         obscureText: _obscure,
-                        style: TextStyle(color: colorScheme.onPrimary),
+                        style: TextStyle(color: colorScheme.onBackground),
                         decoration: _inputDecoration(
                           context,
                           label: 'Password',
@@ -398,12 +379,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                           ),
                         ),
                         validator: _validatePassword,
-                        onChanged: (_) =>
-                            setState(() {}), // update strength bar
+                        onChanged: (_) => setState(() {}),
                       ),
                       const SizedBox(height: 8),
 
-                      // Strength bar
                       LinearProgressIndicator(
                         value: strength,
                         backgroundColor: theme.colorScheme.surfaceVariant,
@@ -415,11 +394,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ),
                       const SizedBox(height: 8),
 
-                      // Confirm
                       TextFormField(
                         controller: _confirmC,
                         obscureText: _obscure,
-                        style: TextStyle(color: colorScheme.onPrimary),
+                        style: TextStyle(color: colorScheme.onBackground),
                         decoration: _inputDecoration(
                           context,
                           label: 'Konfirmasi Password',
@@ -430,18 +408,16 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ),
                       const SizedBox(height: 16),
 
-                      // Terms
                       Row(
                         children: [
                           Checkbox(
                             value: _agreeTerms,
                             onChanged: loading
                                 ? null
-                                : (v) =>
-                                      setState(() => _agreeTerms = v ?? false),
+                                : (v) => setState(() => _agreeTerms = v ?? false),
                             fillColor: WidgetStateProperty.resolveWith<Color>(
                               (states) => states.contains(WidgetState.selected)
-                                  ? colorScheme.onPrimary
+                                  ? colorScheme.primary
                                   : colorScheme.surface,
                             ),
                             side: BorderSide(
@@ -456,13 +432,14 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                   TextSpan(
                                     text: 'Saya menyetujui ',
                                     style: TextStyle(
-                                        color: colorScheme.onBackground
-                                            .withOpacity(0.7)),
+                                      color: colorScheme.onBackground
+                                          .withOpacity(0.7),
+                                    ),
                                   ),
                                   TextSpan(
                                     text: 'Syarat & Ketentuan',
                                     style: TextStyle(
-                                      color: colorScheme.onPrimary,
+                                      color: colorScheme.primary,
                                       fontWeight: FontWeight.bold,
                                       decoration: TextDecoration.underline,
                                     ),
@@ -470,13 +447,14 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                   TextSpan(
                                     text: ' dan ',
                                     style: TextStyle(
-                                        color: colorScheme.onBackground
-                                            .withOpacity(0.7)),
+                                      color: colorScheme.onBackground
+                                          .withOpacity(0.7),
+                                    ),
                                   ),
                                   TextSpan(
                                     text: 'Kebijakan Privasi',
                                     style: TextStyle(
-                                      color: colorScheme.onPrimary,
+                                      color: colorScheme.primary,
                                       fontWeight: FontWeight.bold,
                                       decoration: TextDecoration.underline,
                                     ),
@@ -489,7 +467,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ),
                       const SizedBox(height: 24),
 
-                      // Register button
                       ElevatedButton(
                         onPressed: loading ? null : _register,
                         style: ElevatedButton.styleFrom(
@@ -522,34 +499,33 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ),
                       const SizedBox(height: 16),
 
-                      // Divider
                       Row(
                         children: [
                           Expanded(
-                              child: Divider(
-                                  color:
-                                      colorScheme.onBackground.withOpacity(0.7))),
+                            child: Divider(
+                              color: colorScheme.onBackground.withOpacity(0.7),
+                            ),
+                          ),
                           Padding(
                             padding:
                                 const EdgeInsets.symmetric(horizontal: 16),
                             child: Text(
                               'atau daftar dengan',
                               style: TextStyle(
-                                color:
-                                    colorScheme.onBackground.withOpacity(0.7),
+                                color: colorScheme.onBackground.withOpacity(0.7),
                                 fontSize: 14,
                               ),
                             ),
                           ),
                           Expanded(
-                              child: Divider(
-                                  color:
-                                      colorScheme.onBackground.withOpacity(0.7))),
+                            child: Divider(
+                              color: colorScheme.onBackground.withOpacity(0.7),
+                            ),
+                          ),
                         ],
                       ),
                       const SizedBox(height: 16),
 
-                      // Google (placeholder)
                       OutlinedButton.icon(
                         onPressed: loading ? null : _registerWithGoogle,
                         icon: Image.asset(
@@ -560,7 +536,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         label: Text(
                           'Google',
                           style: TextStyle(
-                            color: colorScheme.onPrimary,
+                            color: colorScheme.onBackground,
                             fontWeight: FontWeight.w500,
                           ),
                         ),
@@ -576,15 +552,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       ),
                       const SizedBox(height: 24),
 
-                      // Link ke login
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           Text(
                             'Sudah punya akun? ',
                             style: TextStyle(
-                                color:
-                                    colorScheme.onBackground.withOpacity(0.7)),
+                                color: colorScheme.onBackground.withOpacity(0.7)),
                           ),
                           TextButton(
                             onPressed: loading
@@ -601,7 +575,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                             child: Text(
                               'Masuk di sini',
                               style: TextStyle(
-                                color: colorScheme.onPrimary,
+                                color: colorScheme.primary,
                                 fontWeight: FontWeight.bold,
                                 decoration: TextDecoration.underline,
                               ),
@@ -615,15 +589,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
               ),
             ),
           ),
-
-          // Loading overlay
           if (loading)
             Container(
               color: colorScheme.onBackground.withOpacity(0.26),
               child: Center(
                 child: CircularProgressIndicator(
                   valueColor:
-                      AlwaysStoppedAnimation<Color>(colorScheme.onPrimary),
+                      AlwaysStoppedAnimation<Color>(colorScheme.primary),
                 ),
               ),
             ),

--- a/lib/screens/auth/verification_screen.dart
+++ b/lib/screens/auth/verification_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
 
 class VerificationScreen extends StatefulWidget {
@@ -142,6 +143,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final isDarkMode = theme.brightness == Brightness.dark;
 
     if (_initialLoading) {
       return Scaffold(
@@ -153,23 +155,33 @@ class _VerificationScreenState extends State<VerificationScreen> {
     }
 
     return Scaffold(
-      backgroundColor: colorScheme.primary,
       body: Stack(
         children: [
-          // Background gradient
           Positioned.fill(
             child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [colorScheme.primary, colorScheme.background],
-                ),
+              color: colorScheme.background,
+              child: Stack(
+                children: [
+                  AppTheme.bubble(
+                    context: context,
+                    size: 200,
+                    top: -50,
+                    right: -50,
+                    opacity: isDarkMode ? 0.1 : 0.03,
+                    usePrimaryColor: true,
+                  ),
+                  AppTheme.bubble(
+                    context: context,
+                    size: 150,
+                    bottom: -30,
+                    left: -30,
+                    opacity: isDarkMode ? 0.08 : 0.03,
+                    usePrimaryColor: true,
+                  ),
+                ],
               ),
             ),
           ),
-
-          // Content
           SafeArea(
             child: Center(
               child: SingleChildScrollView(
@@ -181,7 +193,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                       'Verifikasi Email',
                       textAlign: TextAlign.center,
                       style: theme.textTheme.headlineMedium?.copyWith(
-                        color: colorScheme.onPrimary,
+                        color: colorScheme.onBackground,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
@@ -190,10 +202,10 @@ class _VerificationScreenState extends State<VerificationScreen> {
                     Container(
                       padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
-                        color: colorScheme.onPrimary.withOpacity(0.1),
+                        color: colorScheme.surface,
                         borderRadius: BorderRadius.circular(16),
                         border: Border.all(
-                          color: colorScheme.onPrimary.withOpacity(0.2),
+                          color: colorScheme.outline.withOpacity(0.2),
                           width: 1,
                         ),
                       ),
@@ -244,18 +256,17 @@ class _VerificationScreenState extends State<VerificationScreen> {
 
                     const SizedBox(height: 24),
 
-                    // Kirim ulang
                     SizedBox(
                       height: 50,
                       child: OutlinedButton(
                         onPressed: (_canResend && !_resending) ? _resend : null,
                         style: OutlinedButton.styleFrom(
-                          foregroundColor: colorScheme.onPrimary,
+                          foregroundColor: colorScheme.primary,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12),
                           ),
                           side: BorderSide(
-                            color: colorScheme.onPrimary,
+                            color: colorScheme.primary,
                             width: 1.5,
                           ),
                         ),
@@ -265,7 +276,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                                 height: 24,
                                 child: CircularProgressIndicator(
                                   strokeWidth: 2,
-                                  color: colorScheme.onPrimary,
+                                  color: colorScheme.primary,
                                 ),
                               )
                             : Text(
@@ -277,7 +288,6 @@ class _VerificationScreenState extends State<VerificationScreen> {
                     ),
                     const SizedBox(height: 12),
 
-                    // Cek status (manual only)
                     SizedBox(
                       height: 50,
                       child: ElevatedButton.icon(
@@ -308,7 +318,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
                       child: Text(
                         'Kembali ke Halaman Login',
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onPrimary,
+                          color: colorScheme.primary,
                           decoration: TextDecoration.underline,
                         ),
                       ),


### PR DESCRIPTION
## Summary
- replace gradient decorations in auth screens with color background and AppTheme bubbles
- wrap content in Stack-backed containers using colorScheme.background
- ensure login, register, verification and reset password screens use consistent bubble layout

## Testing
- `dart format lib/screens/auth/login_screen.dart lib/screens/auth/register_screen.dart lib/screens/auth/verification_screen.dart lib/screens/auth/forgot_password_screen.dart` *(fails: command not found)*
- `flutter format lib/screens/auth/login_screen.dart lib/screens/auth/register_screen.dart lib/screens/auth/verification_screen.dart lib/screens/auth/forgot_password_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f561700832baafb3597f8f68dcb