### PR TITLE
Use AppBackground for player screen

### DIFF
--- a/lib/screens/player/player_screen.dart
+++ b/lib/screens/player/player_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:radio_odan_app/audio/audio_player_manager.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:radio_odan_app/providers/radio_station_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class FullPlayer extends StatefulWidget {
   const FullPlayer({super.key});
@@ -66,12 +67,16 @@ class _FullPlayerState extends State<FullPlayer> {
 
       if (currentStation == null) {
         return Scaffold(
-          backgroundColor: theme.colorScheme.background,
-          body: Center(
-            child: Text(
-              'No radio station selected',
-              style: theme.textTheme.bodyMedium,
-            ),
+          body: Stack(
+            children: [
+              const AppBackground(showSmallBubble: true),
+              Center(
+                child: Text(
+                  'No radio station selected',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            ],
           ),
         );
       }
@@ -89,7 +94,6 @@ class _FullPlayerState extends State<FullPlayer> {
         : (currentStation.host ?? 'Unknown');
 
     return Scaffold(
-      backgroundColor: theme.colorScheme.background,
       appBar: AppBar(
         title: Text(
           'Now Playing',
@@ -113,9 +117,12 @@ class _FullPlayerState extends State<FullPlayer> {
           },
         ),
       ),
-      body: SafeArea(
-        child: Column(
-          children: [
+      body: Stack(
+        children: [
+          const AppBackground(showSmallBubble: true),
+          SafeArea(
+            child: Column(
+              children: [
             // === Cover image ===
             Expanded(
               flex: 5,
@@ -331,11 +338,13 @@ class _FullPlayerState extends State<FullPlayer> {
                   },
                 ),
               ),
-            ),
-            const SizedBox(height: 30),
-          ],
+              ),
+              const SizedBox(height: 30),
+            ],
+          ),
         ),
-      ),
+      ],
+    ),
     );
   }
 }

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
+
+/// A reusable background widget with decorative bubbles.
+///
+/// Shows two large bubbles by default and an optional small bubble
+/// to match the design of various screens.
+class AppBackground extends StatelessWidget {
+  final bool showSmallBubble;
+
+  const AppBackground({super.key, this.showSmallBubble = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Positioned.fill(
+      child: Container(
+        color: theme.colorScheme.background,
+        child: Stack(
+          children: [
+            // Top-right large bubble
+            AppTheme.bubble(
+              context: context,
+              size: 200,
+              top: -50,
+              right: -50,
+              opacity: isDark ? 0.1 : 0.03,
+              usePrimaryColor: true,
+            ),
+            // Bottom-left medium bubble
+            AppTheme.bubble(
+              context: context,
+              size: 150,
+              bottom: -30,
+              left: -30,
+              opacity: isDark ? 0.08 : 0.03,
+              usePrimaryColor: true,
+            ),
+            if (showSmallBubble)
+              AppTheme.bubble(
+                context: context,
+                size: 50,
+                top: 100,
+                left: 100,
+                opacity: isDark ? 0.06 : 0.02,
+                usePrimaryColor: true,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add reusable `AppBackground` widget with optional small bubble
- Overlay `AppBackground` under player content via `Stack`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f6ee104832ba1a535b29dbd59bd