### PR TITLE
refactor: use AppBackground for gradient screens

### DIFF
--- a/lib/screens/artikel/artikel_detail_screen.dart
+++ b/lib/screens/artikel/artikel_detail_screen.dart
@@ -4,7 +4,7 @@ import 'package:html/dom.dart' as dom;
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:radio_odan_app/config/app_colors.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/loading/loading_widget.dart';
@@ -105,61 +105,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
             backgroundColor: Theme.of(context).scaffoldBackgroundColor,
             child: Stack(
               children: [
-                // Background with gradient overlay
-                Positioned.fill(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Theme.of(context).primaryColor,
-                          Theme.of(context).scaffoldBackgroundColor,
-                        ],
-                      ),
-                    ),
-                    child: Stack(
-                      children: [
-                        Positioned(
-                          top: -50,
-                          right: -50,
-                          child: Container(
-                            width: 200,
-                            height: 200,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: colorScheme.primary.withOpacity(0.1),
-                            ),
-                          ),
-                        ),
-                        Positioned(
-                          bottom: -30,
-                          left: -30,
-                          child: Container(
-                            width: 150,
-                            height: 150,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: colorScheme.secondary.withOpacity(0.1),
-                            ),
-                          ),
-                        ),
-                        Positioned(
-                          top: 100,
-                          left: 100,
-                          child: Container(
-                            width: 50,
-                            height: 50,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: colorScheme.tertiary.withOpacity(0.1),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+                const AppBackground(),
 
                 // Content
                 SingleChildScrollView(

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:provider/provider.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
-
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -182,20 +181,8 @@ class _LoginScreenState extends State<LoginScreen> {
       child: Scaffold(
         body: Stack(
           children: [
-            // Background gradient
-            Positioned.fill(
-              child: Container(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      theme.colorScheme.primary,
-                      theme.colorScheme.background,
-                    ],
-                  ),
-                ),
-                child: SafeArea(
+            const AppBackground(),
+            SafeArea(
                   child: SingleChildScrollView(
                     padding: const EdgeInsets.all(24.0),
                     child: Column(

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
-
 import 'package:radio_odan_app/config/app_routes.dart';
 import 'package:radio_odan_app/config/app_colors.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
 
 class RegisterScreen extends StatefulWidget {
@@ -278,46 +278,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
     return Scaffold(
       body: Stack(
         children: [
-          // Background gradient + circle waves
-          Positioned.fill(
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [theme.colorScheme.primary, theme.colorScheme.background],
-                ),
-              ),
-              child: Stack(
-                children: [
-                  Positioned(
-                    top: -100,
-                    right: -100,
-                    child: Container(
-                      width: 300,
-                      height: 300,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: AppColors.white.withOpacity(0.1),
-                      ),
-                    ),
-                  ),
-                  Positioned(
-                    bottom: -150,
-                    left: -50,
-                    child: Container(
-                      width: 400,
-                      height: 400,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: AppColors.white.withOpacity(0.1),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
 
           // Content
           SafeArea(

--- a/lib/screens/auth/verification_screen.dart
+++ b/lib/screens/auth/verification_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
 import 'package:radio_odan_app/config/app_routes.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
 
 class VerificationScreen extends StatefulWidget {
@@ -145,7 +145,6 @@ class _VerificationScreenState extends State<VerificationScreen> {
 
     if (_initialLoading) {
       return Scaffold(
-        backgroundColor: colorScheme.primary,
         body: Center(
           child: CircularProgressIndicator(color: colorScheme.onPrimary),
         ),
@@ -153,21 +152,9 @@ class _VerificationScreenState extends State<VerificationScreen> {
     }
 
     return Scaffold(
-      backgroundColor: colorScheme.primary,
       body: Stack(
         children: [
-          // Background gradient
-          Positioned.fill(
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [colorScheme.primary, colorScheme.background],
-                ),
-              ),
-            ),
-          ),
+          const AppBackground(),
 
           // Content
           SafeArea(

--- a/lib/screens/galeri/album_detail_screen.dart
+++ b/lib/screens/galeri/album_detail_screen.dart
@@ -6,7 +6,7 @@ import 'package:radio_odan_app/providers/album_provider.dart';
 import 'package:radio_odan_app/models/album_model.dart';
 import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class AlbumDetailScreen extends StatefulWidget {
   final String slug;
@@ -68,39 +68,7 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
       backgroundColor: Theme.of(context).colorScheme.background,
       body: Stack(
         children: [
-          // MiniPlayer di sini akan muncul di atas konten
-          const Positioned(left: 0, right: 0, bottom: 0, child: MiniPlayer()),
-          // Background dekoratif
-          Positioned.fill(
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Theme.of(context).colorScheme.surface,
-                    Theme.of(context).colorScheme.background,
-                  ],
-                ),
-              ),
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
 
           Consumer<AlbumProvider>(
             builder: (context, provider, _) {
@@ -128,6 +96,8 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
               return _buildAlbumDetail(context, albumDetail);
             },
           ),
+
+          const Positioned(left: 0, right: 0, bottom: 0, child: MiniPlayer()),
         ],
       ),
     );

--- a/lib/screens/program/program_detail_screen.dart
+++ b/lib/screens/program/program_detail_screen.dart
@@ -6,7 +6,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:radio_odan_app/providers/program_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ProgramDetailScreen extends StatefulWidget {
   const ProgramDetailScreen({super.key});
@@ -180,39 +180,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
           ),
           body: Stack(
             children: [
-              // Background gradient + bubbles
-              Positioned.fill(
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        Theme.of(context).primaryColor,
-                        Theme.of(context).scaffoldBackgroundColor,
-                      ],
-                    ),
-                  ),
-                  child: Stack(
-                    children: [
-                      AppTheme.bubble(context: context, size: 200, top: -50, right: -50),
-                      AppTheme.bubble(
-                        context: context,
-                        size: 150,
-                        bottom: -30,
-                        left: -30,
-                      ),
-                      AppTheme.bubble(
-                        context: context,
-                        size: 50,
-                        top: 100,
-                        left: 100,
-                        opacity: 0.05,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+              const AppBackground(),
 
               // Content states
               if (isLoading)

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
+
+class AppBackground extends StatelessWidget {
+  const AppBackground({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Positioned.fill(
+      child: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              colorScheme.primary,
+              colorScheme.background,
+            ],
+          ),
+        ),
+        child: Stack(
+          children: [
+            AppTheme.bubble(
+              context: context,
+              size: 200,
+              top: -50,
+              right: -50,
+            ),
+            AppTheme.bubble(
+              context: context,
+              size: 150,
+              bottom: -30,
+              left: -30,
+              usePrimaryColor: false,
+            ),
+            AppTheme.bubble(
+              context: context,
+              size: 50,
+              top: 100,
+              left: 100,
+              usePrimaryColor: false,
+              opacity: 0.05,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- create reusable `AppBackground` widget for gradient + bubbles
- replace manual gradient backgrounds with `AppBackground`
- drop redundant scaffold background color in verification screen

## Testing
- `dart format lib/widgets/common/app_background.dart lib/screens/auth/login_screen.dart lib/screens/auth/register_screen.dart lib/screens/auth/verification_screen.dart lib/screens/artikel/artikel_detail_screen.dart lib/screens/program/program_detail_screen.dart lib/screens/galeri/album_detail_screen.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f5ed1fc832b9cfe819d9293eca7