### PR TITLE
feat: add reusable app background widget

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 
 import 'package:radio_odan_app/config/app_routes.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -182,20 +183,8 @@ class _LoginScreenState extends State<LoginScreen> {
       child: Scaffold(
         body: Stack(
           children: [
-            // Background gradient
-            Positioned.fill(
-              child: Container(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      theme.colorScheme.primary,
-                      theme.colorScheme.background,
-                    ],
-                  ),
-                ),
-                child: SafeArea(
+            const AppBackground(),
+            SafeArea(
                   child: SingleChildScrollView(
                     padding: const EdgeInsets.all(24.0),
                     child: Column(
@@ -543,11 +532,9 @@ class _LoginScreenState extends State<LoginScreen> {
                     ),
                   ),
                 ),
-              ),
+              ],
             ),
-          ],
-        ),
-      ),
+          ),
     );
   }
 }

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import 'package:radio_odan_app/config/app_theme.dart';
+
+class AppBackground extends StatelessWidget {
+  const AppBackground({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Positioned.fill(
+      child: Container(
+        color: theme.colorScheme.background,
+        child: Stack(
+          children: [
+            AppTheme.bubble(
+              context: context,
+              size: 200,
+              top: -50,
+              right: -50,
+              opacity: isDark ? 0.1 : 0.03,
+              usePrimaryColor: true,
+            ),
+            AppTheme.bubble(
+              context: context,
+              size: 150,
+              bottom: -30,
+              left: -30,
+              opacity: isDark ? 0.08 : 0.03,
+              usePrimaryColor: true,
+            ),
+            AppTheme.bubble(
+              context: context,
+              size: 50,
+              top: 100,
+              left: 100,
+              opacity: isDark ? 0.06 : 0.02,
+              usePrimaryColor: true,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `AppBackground` widget with standard bubbles
- use `AppBackground` and `SafeArea` on login screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f4f0814832b950fa2c55f3f95a4