### PR TITLE
refactor: use AppBackground in auth screens

### DIFF
--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:radio_odan_app/services/auth_service.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
   const ForgotPasswordScreen({super.key});
@@ -58,36 +58,11 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDarkMode = theme.brightness == Brightness.dark;
     return Scaffold(
       appBar: AppBar(title: const Text('Lupa Password')),
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: theme.colorScheme.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           Center(
             child: SingleChildScrollView(
               padding: const EdgeInsets.all(24),

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -5,8 +5,8 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -172,7 +172,6 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final loading = context.watch<AuthProvider>().loading;
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     return PopScope(
       canPop: false,
@@ -184,32 +183,7 @@ class _LoginScreenState extends State<LoginScreen> {
       child: Scaffold(
         body: Stack(
           children: [
-            // Background bubbles
-            Positioned.fill(
-              child: Container(
-                color: theme.colorScheme.background,
-                child: Stack(
-                  children: [
-                    AppTheme.bubble(
-                      context: context,
-                      size: 200,
-                      top: -50,
-                      right: -50,
-                      opacity: isDarkMode ? 0.1 : 0.03,
-                      usePrimaryColor: true,
-                    ),
-                    AppTheme.bubble(
-                      context: context,
-                      size: 150,
-                      bottom: -30,
-                      left: -30,
-                      opacity: isDarkMode ? 0.08 : 0.03,
-                      usePrimaryColor: true,
-                    ),
-                  ],
-                ),
-              ),
-            ),
+            const AppBackground(),
             SafeArea(
               child: SingleChildScrollView(
                 padding: const EdgeInsets.all(24.0),

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -4,8 +4,8 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -274,36 +274,11 @@ class _RegisterScreenState extends State<RegisterScreen> {
     final colorScheme = theme.colorScheme;
     final loading = context.watch<AuthProvider>().loading;
     final strength = _passwordStrength(_passC.text);
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     return Scaffold(
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: theme.colorScheme.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           SafeArea(
             child: Center(
               child: SingleChildScrollView(

--- a/lib/screens/auth/verification_screen.dart
+++ b/lib/screens/auth/verification_screen.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class VerificationScreen extends StatefulWidget {
   final String email;
@@ -143,7 +143,6 @@ class _VerificationScreenState extends State<VerificationScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     if (_initialLoading) {
       return Scaffold(
@@ -157,31 +156,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
     return Scaffold(
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: colorScheme.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           SafeArea(
             child: Center(
               child: SingleChildScrollView(

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -6,7 +6,7 @@ class AppBackground extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final bubbleOpacity = theme.brightness == Brightness.dark ? 0.05 : 0.1;
+    final bubbleOpacity = theme.brightness == Brightness.dark ? 0.08 : 0.1;
 
     return SizedBox.expand(
       child: Container(


### PR DESCRIPTION
## Summary
- replace gradient containers in auth flow with reusable `AppBackground`
- keep login logo above background layer
- soften dark mode bubbles

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be149a70f4832b90fd4db5441f219b