### PR TITLE
refactor: remove gradients and use AppBackground

### DIFF
--- a/lib/screens/artikel/artikel_detail_screen.dart
+++ b/lib/screens/artikel/artikel_detail_screen.dart
@@ -4,11 +4,11 @@ import 'package:html/dom.dart' as dom;
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/loading/loading_widget.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ArtikelDetailScreen extends StatefulWidget {
   final String artikelSlug;
@@ -104,43 +104,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
             backgroundColor: Theme.of(context).scaffoldBackgroundColor,
             child: Stack(
               children: [
-                // Background with gradient overlay
-                Positioned.fill(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Theme.of(context).primaryColor,
-                          Theme.of(context).scaffoldBackgroundColor,
-                        ],
-                      ),
-                    ),
-                    child: Stack(
-                      children: [
-                        AppTheme.bubble(
-                          context: context,
-                          size: 200,
-                          top: -50,
-                          right: -50,
-                        ),
-                        AppTheme.bubble(
-                          context: context,
-                          size: 150,
-                          bottom: -30,
-                          left: -30,
-                        ),
-                        AppTheme.bubble(
-                          context: context,
-                          size: 50,
-                          top: 100,
-                          left: 100,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+                const Positioned.fill(child: AppBackground()),
 
                 // Content
                 SingleChildScrollView(

--- a/lib/screens/galeri/album_detail_screen.dart
+++ b/lib/screens/galeri/album_detail_screen.dart
@@ -6,7 +6,7 @@ import 'package:radio_odan_app/providers/album_provider.dart';
 import 'package:radio_odan_app/models/album_model.dart';
 import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class AlbumDetailScreen extends StatefulWidget {
   final String slug;
@@ -68,39 +68,7 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
       backgroundColor: Theme.of(context).colorScheme.background,
       body: Stack(
         children: [
-          // MiniPlayer di sini akan muncul di atas konten
-          const Positioned(left: 0, right: 0, bottom: 0, child: MiniPlayer()),
-          // Background dekoratif
-          Positioned.fill(
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Theme.of(context).colorScheme.surface,
-                    Theme.of(context).colorScheme.background,
-                  ],
-                ),
-              ),
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const Positioned.fill(child: AppBackground()),
 
           Consumer<AlbumProvider>(
             builder: (context, provider, _) {
@@ -128,6 +96,8 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
               return _buildAlbumDetail(context, albumDetail);
             },
           ),
+
+          const Positioned(left: 0, right: 0, bottom: 0, child: MiniPlayer()),
         ],
       ),
     );

--- a/lib/screens/program/program_detail_screen.dart
+++ b/lib/screens/program/program_detail_screen.dart
@@ -6,7 +6,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:radio_odan_app/providers/program_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ProgramDetailScreen extends StatefulWidget {
   const ProgramDetailScreen({super.key});
@@ -180,39 +180,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
           ),
           body: Stack(
             children: [
-              // Background gradient + bubbles
-              Positioned.fill(
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        Theme.of(context).primaryColor,
-                        Theme.of(context).scaffoldBackgroundColor,
-                      ],
-                    ),
-                  ),
-                  child: Stack(
-                    children: [
-                      AppTheme.bubble(context: context, size: 200, top: -50, right: -50),
-                      AppTheme.bubble(
-                        context: context,
-                        size: 150,
-                        bottom: -30,
-                        left: -30,
-                      ),
-                      AppTheme.bubble(
-                        context: context,
-                        size: 50,
-                        top: 100,
-                        left: 100,
-                        opacity: 0.05,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+              const Positioned.fill(child: AppBackground()),
 
               // Content states
               if (isLoading)
@@ -335,5 +303,4 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
     );
   }
 
-  // _bubble method removed - using AppTheme.bubble instead
 }

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/config/app_theme.dart';
 
 class AppBackground extends StatelessWidget {
   const AppBackground({super.key});
@@ -6,45 +7,28 @@ class AppBackground extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final bubbleOpacity = theme.brightness == Brightness.dark ? 0.05 : 0.1;
+    final isDarkMode = theme.brightness == Brightness.dark;
 
     return SizedBox.expand(
       child: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [
-              theme.colorScheme.primary,
-              theme.colorScheme.background,
-            ],
-          ),
-        ),
+        color: theme.colorScheme.background,
         child: Stack(
           children: [
-            Positioned(
-              top: -100,
-              right: -100,
-              child: Container(
-                width: 300,
-                height: 300,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: theme.colorScheme.onPrimary.withOpacity(bubbleOpacity),
-                ),
-              ),
+            AppTheme.bubble(
+              context: context,
+              size: 200,
+              top: -50,
+              right: -50,
+              opacity: isDarkMode ? 0.1 : 0.03,
+              usePrimaryColor: true,
             ),
-            Positioned(
-              bottom: -150,
-              left: -50,
-              child: Container(
-                width: 400,
-                height: 400,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: theme.colorScheme.onPrimary.withOpacity(bubbleOpacity),
-                ),
-              ),
+            AppTheme.bubble(
+              context: context,
+              size: 150,
+              bottom: -30,
+              left: -30,
+              opacity: isDarkMode ? 0.08 : 0.03,
+              usePrimaryColor: true,
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- simplify background decoration by using `AppBackground`
- clean up detail screens to drop gradient `BoxDecoration`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be148ce10c832b9020aea8df9207e3