### PR TITLE
Use AppBackground in player screen

### DIFF
--- a/lib/screens/player/player_screen.dart
+++ b/lib/screens/player/player_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:radio_odan_app/audio/audio_player_manager.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:radio_odan_app/providers/radio_station_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class FullPlayer extends StatefulWidget {
   const FullPlayer({super.key});
@@ -66,12 +67,16 @@ class _FullPlayerState extends State<FullPlayer> {
 
       if (currentStation == null) {
         return Scaffold(
-          backgroundColor: theme.colorScheme.background,
-          body: Center(
-            child: Text(
-              'No radio station selected',
-              style: theme.textTheme.bodyMedium,
-            ),
+          body: Stack(
+            children: [
+              const AppBackground(),
+              Center(
+                child: Text(
+                  'No radio station selected',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            ],
           ),
         );
       }
@@ -89,7 +94,6 @@ class _FullPlayerState extends State<FullPlayer> {
         : (currentStation.host ?? 'Unknown');
 
     return Scaffold(
-      backgroundColor: theme.colorScheme.background,
       appBar: AppBar(
         title: Text(
           'Now Playing',
@@ -113,9 +117,12 @@ class _FullPlayerState extends State<FullPlayer> {
           },
         ),
       ),
-      body: SafeArea(
-        child: Column(
-          children: [
+      body: Stack(
+        children: [
+          const AppBackground(),
+          SafeArea(
+            child: Column(
+              children: [
             // === Cover image ===
             Expanded(
               flex: 5,
@@ -336,6 +343,8 @@ class _FullPlayerState extends State<FullPlayer> {
           ],
         ),
       ),
-    );
+    ],
+  ),
+);
   }
 }

--- a/lib/widgets/common/app_background.dart
+++ b/lib/widgets/common/app_background.dart
@@ -46,6 +46,18 @@ class AppBackground extends StatelessWidget {
                 ),
               ),
             ),
+            Positioned(
+              bottom: -40,
+              right: -40,
+              child: Container(
+                width: 120,
+                height: 120,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: theme.colorScheme.onPrimary.withOpacity(bubbleOpacity),
+                ),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- Layer player UI over new AppBackground gradient and bubbles
- Add extra decorative bubble for balanced layout

## Testing
- `dart format lib/screens/player/player_screen.dart lib/widgets/common/app_background.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be14c0ce44832bacffbb188bd06666