### PR TITLE
refactor: use AppBackground widget

### DIFF
--- a/lib/screens/artikel/artikel_detail_screen.dart
+++ b/lib/screens/artikel/artikel_detail_screen.dart
@@ -4,11 +4,11 @@ import 'package:html/dom.dart' as dom;
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/loading/loading_widget.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ArtikelDetailScreen extends StatefulWidget {
   final String artikelSlug;
@@ -104,43 +104,7 @@ class _ArtikelDetailScreenState extends State<ArtikelDetailScreen> {
             backgroundColor: Theme.of(context).scaffoldBackgroundColor,
             child: Stack(
               children: [
-                // Background with gradient overlay
-                Positioned.fill(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Theme.of(context).primaryColor,
-                          Theme.of(context).scaffoldBackgroundColor,
-                        ],
-                      ),
-                    ),
-                    child: Stack(
-                      children: [
-                        AppTheme.bubble(
-                          context: context,
-                          size: 200,
-                          top: -50,
-                          right: -50,
-                        ),
-                        AppTheme.bubble(
-                          context: context,
-                          size: 150,
-                          bottom: -30,
-                          left: -30,
-                        ),
-                        AppTheme.bubble(
-                          context: context,
-                          size: 50,
-                          top: 100,
-                          left: 100,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+                const AppBackground(),
 
                 // Content
                 SingleChildScrollView(

--- a/lib/screens/artikel/artikel_screen.dart
+++ b/lib/screens/artikel/artikel_screen.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/models/artikel_model.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/widgets/skeleton/artikel_all_skeleton.dart';
 import 'artikel_detail_screen.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ArtikelScreen extends StatefulWidget {
   const ArtikelScreen({super.key});
@@ -111,7 +111,6 @@ class _ArtikelScreenState extends State<ArtikelScreen>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDarkMode = theme.brightness == Brightness.dark;
     
     return Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
@@ -121,33 +120,7 @@ class _ArtikelScreenState extends State<ArtikelScreen>
       ),
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: theme.colorScheme.background,
-              child: Stack(
-                children: [
-                  // Top-right bubble
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: 50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  // Bottom-left bubble
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           Consumer<ArtikelProvider>(builder: (_, p, __) => _buildBody(p)),
         ],
       ),

--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:radio_odan_app/services/auth_service.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
   const ForgotPasswordScreen({super.key});
@@ -58,36 +58,11 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDarkMode = theme.brightness == Brightness.dark;
     return Scaffold(
       appBar: AppBar(title: const Text('Lupa Password')),
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: theme.colorScheme.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           Center(
             child: SingleChildScrollView(
               padding: const EdgeInsets.all(24),

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -5,8 +5,8 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -172,7 +172,6 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final loading = context.watch<AuthProvider>().loading;
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     return PopScope(
       canPop: false,
@@ -184,32 +183,7 @@ class _LoginScreenState extends State<LoginScreen> {
       child: Scaffold(
         body: Stack(
           children: [
-            // Background bubbles
-            Positioned.fill(
-              child: Container(
-                color: theme.colorScheme.background,
-                child: Stack(
-                  children: [
-                    AppTheme.bubble(
-                      context: context,
-                      size: 200,
-                      top: -50,
-                      right: -50,
-                      opacity: isDarkMode ? 0.1 : 0.03,
-                      usePrimaryColor: true,
-                    ),
-                    AppTheme.bubble(
-                      context: context,
-                      size: 150,
-                      bottom: -30,
-                      left: -30,
-                      opacity: isDarkMode ? 0.08 : 0.03,
-                      usePrimaryColor: true,
-                    ),
-                  ],
-                ),
-              ),
-            ),
+            const AppBackground(),
             SafeArea(
               child: SingleChildScrollView(
                 padding: const EdgeInsets.all(24.0),

--- a/lib/screens/auth/register_screen.dart
+++ b/lib/screens/auth/register_screen.dart
@@ -4,8 +4,8 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -274,36 +274,11 @@ class _RegisterScreenState extends State<RegisterScreen> {
     final colorScheme = theme.colorScheme;
     final loading = context.watch<AuthProvider>().loading;
     final strength = _passwordStrength(_passC.text);
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     return Scaffold(
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: theme.colorScheme.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           SafeArea(
             child: Center(
               child: SingleChildScrollView(

--- a/lib/screens/auth/verification_screen.dart
+++ b/lib/screens/auth/verification_screen.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/auth_provider.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class VerificationScreen extends StatefulWidget {
   final String email;
@@ -143,7 +143,6 @@ class _VerificationScreenState extends State<VerificationScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     if (_initialLoading) {
       return Scaffold(
@@ -157,31 +156,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
     return Scaffold(
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: colorScheme.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           SafeArea(
             child: Center(
               child: SingleChildScrollView(

--- a/lib/screens/event/event_detail_screen.dart
+++ b/lib/screens/event/event_detail_screen.dart
@@ -4,9 +4,9 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:intl/intl.dart';
 
 import 'package:radio_odan_app/models/event_model.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class EventDetailScreen extends StatelessWidget {
   final Event event;
@@ -164,7 +164,6 @@ class EventDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     return Scaffold(
       backgroundColor: colors.background,
@@ -186,32 +185,7 @@ class EventDetailScreen extends StatelessWidget {
         builder: (context, constraints) {
           return Stack(
             children: [
-              // Background gradient + bubbles
-              Positioned.fill(
-                child: Container(
-                  color: colors.background,
-                  child: Stack(
-                    children: [
-                      AppTheme.bubble(
-                        context: context,
-                        size: 200,
-                        top: -50,
-                        right: -50,
-                        opacity: isDarkMode ? 0.1 : 0.03,
-                        usePrimaryColor: true,
-                      ),
-                      AppTheme.bubble(
-                        context: context,
-                        size: 150,
-                        bottom: -30,
-                        left: -30,
-                        opacity: isDarkMode ? 0.15 : 0.04,
-                        usePrimaryColor: true,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+              const AppBackground(),
 
               // Main content
               Column(

--- a/lib/screens/event/event_screen.dart
+++ b/lib/screens/event/event_screen.dart
@@ -5,11 +5,11 @@ import 'package:collection/collection.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
 
 import 'package:radio_odan_app/models/event_model.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/event_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
 import 'package:radio_odan_app/widgets/skeleton/event_skeleton.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class AllEventsScreen extends StatefulWidget {
   const AllEventsScreen({super.key});
@@ -102,7 +102,6 @@ class _AllEventsScreenState extends State<AllEventsScreen>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final isDarkMode = theme.brightness == Brightness.dark;
     
     return Scaffold(
       key: const Key('all_events_screen'),
@@ -113,31 +112,7 @@ class _AllEventsScreenState extends State<AllEventsScreen>
       backgroundColor: colors.background,
       body: Stack(
         children: [
-          Positioned.fill(
-            child: Container(
-              color: colors.surface,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: 50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 250,
-                    bottom: -50,
-                    left: -50,
-                    opacity: isDarkMode ? 0.15 : 0.04,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           _buildBody(),
           const Positioned(left: 0, right: 0, bottom: 0, child: MiniPlayer()),
         ],

--- a/lib/screens/galeri/album_detail_screen.dart
+++ b/lib/screens/galeri/album_detail_screen.dart
@@ -6,7 +6,7 @@ import 'package:radio_odan_app/providers/album_provider.dart';
 import 'package:radio_odan_app/models/album_model.dart';
 import 'package:radio_odan_app/config/app_colors.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class AlbumDetailScreen extends StatefulWidget {
   final String slug;
@@ -70,37 +70,7 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
         children: [
           // MiniPlayer di sini akan muncul di atas konten
           const Positioned(left: 0, right: 0, bottom: 0, child: MiniPlayer()),
-          // Background dekoratif
-          Positioned.fill(
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Theme.of(context).colorScheme.surface,
-                    Theme.of(context).colorScheme.background,
-                  ],
-                ),
-              ),
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
 
           Consumer<AlbumProvider>(
             builder: (context, provider, _) {

--- a/lib/screens/galeri/album_screen.dart
+++ b/lib/screens/galeri/album_screen.dart
@@ -8,8 +8,8 @@ import 'package:radio_odan_app/providers/album_provider.dart';
 import 'package:radio_odan_app/models/album_model.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'album_detail_screen.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class AllAlbumsScreen extends StatefulWidget {
   const AllAlbumsScreen({super.key});
@@ -132,36 +132,10 @@ class _AllAlbumsScreenState extends State<AllAlbumsScreen>
   Widget _buildBody() {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     return Stack(
       children: [
-        // Background
-        Positioned.fill(
-          child: Container(
-            color: colors.background,
-            child: Stack(
-              children: [
-                AppTheme.bubble(
-                  context: context,
-                  size: 200,
-                  top: -50,
-                  right: -50,
-                  opacity: isDarkMode ? 0.1 : 0.03,
-                  usePrimaryColor: true,
-                ),
-                AppTheme.bubble(
-                  context: context,
-                  size: 150,
-                  bottom: -30,
-                  left: -30,
-                  opacity: isDarkMode ? 0.15 : 0.04,
-                  usePrimaryColor: true,
-                ),
-              ],
-            ),
-          ),
-        ),
+        const AppBackground(),
 
         Consumer<AlbumProvider>(
           builder: (context, albumProvider, _) {

--- a/lib/screens/galeri/galeri_screen.dart
+++ b/lib/screens/galeri/galeri_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/providers/album_provider.dart';
 import 'package:radio_odan_app/providers/video_provider.dart';
 import 'widget/video_list.dart';
 import 'widget/album_list.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class GaleriScreen extends StatefulWidget {
   const GaleriScreen({super.key});
@@ -50,7 +50,6 @@ class _GaleriScreenState extends State<GaleriScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final isDarkMode = theme.brightness == Brightness.dark;
     
     return Scaffold(
       key: _scaffoldKey,
@@ -61,43 +60,7 @@ class _GaleriScreenState extends State<GaleriScreen> {
       ),
       body: Stack(
         children: [
-          // Background with gradient and bubbles
-          Positioned.fill(
-            child: Container(
-              color: colors.background,
-              child: Stack(
-                children: [
-                  // Large bubble top right
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  // Medium bubble bottom left
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  // Small bubble center
-                  AppTheme.bubble(
-                    context: context,
-                    size: 50,
-                    top: 100,
-                    left: 100,
-                    opacity: isDarkMode ? 0.06 : 0.02,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           // Main Content with RefreshIndicator
           SafeArea(
             child: RefreshIndicator(

--- a/lib/screens/galeri/video_screen.dart
+++ b/lib/screens/galeri/video_screen.dart
@@ -11,7 +11,7 @@ import 'package:radio_odan_app/models/video_model.dart';
 import 'package:radio_odan_app/providers/video_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class AllVideosScreen extends StatefulWidget {
   const AllVideosScreen({Key? key}) : super(key: key);
@@ -145,7 +145,6 @@ class _AllVideosScreenState extends State<AllVideosScreen>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final isDarkMode = theme.brightness == Brightness.dark;
 
     return Scaffold(
       backgroundColor: colors.background,
@@ -156,43 +155,10 @@ class _AllVideosScreenState extends State<AllVideosScreen>
       ),
       body: Stack(
         children: [
-          // Background bubbles
-          Positioned.fill(
-            child: Container(
-              color: colors.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.15 : 0.04,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 80,
-                    top: 100,
-                    left: 100,
-                    opacity: isDarkMode ? 0.08 : 0.02,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+            const AppBackground(),
 
-          // Content
-          Positioned.fill(
+            // Content
+            Positioned.fill(
             child: Consumer<VideoProvider>(
               builder: (context, vp, _) {
                 return RefreshIndicator(
@@ -209,9 +175,6 @@ class _AllVideosScreenState extends State<AllVideosScreen>
       bottomNavigationBar: const MiniPlayer(),
     );
   }
-
-  // _bubble method removed - using AppTheme.bubble instead
-
   Widget _buildLoadingSkeleton() {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 // Config
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/config/app_colors.dart';
 
 // Providers
@@ -10,11 +9,11 @@ import 'package:radio_odan_app/providers/program_provider.dart';
 import 'package:radio_odan_app/providers/event_provider.dart';
 import 'package:radio_odan_app/providers/artikel_provider.dart';
 import 'package:radio_odan_app/providers/penyiar_provider.dart';
-import 'package:radio_odan_app/providers/theme_provider.dart'; // Add theme provider
 
 // Widgets
 import 'package:radio_odan_app/widgets/common/app_header.dart';
 import 'package:radio_odan_app/widgets/common/app_drawer.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 // Home Widgets
 import 'package:radio_odan_app/screens/home/widget/penyiar_list.dart';
@@ -125,8 +124,6 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    final themeProvider = Provider.of<ThemeProvider>(context);
-    final isDarkMode = themeProvider.themeMode == ThemeMode.dark;
     final theme = Theme.of(context);
 
     return Scaffold(
@@ -138,43 +135,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           return Stack(
             key: const Key('home_stack'),
             children: [
-              // Background with theme-aware colors
-              Positioned.fill(
-                child: Container(
-                  color: theme.colorScheme.background,
-                  child: Stack(
-                    children: [
-                      // Top-right bubble (large)
-                      AppTheme.bubble(
-                        context: context,
-                        size: 200,
-                        top: -50,
-                        right: -50,
-                        opacity: isDarkMode ? 0.1 : 0.03,
-                        usePrimaryColor: true,
-                      ),
-                      // Bottom-left bubble (medium)
-                      AppTheme.bubble(
-                        context: context,
-                        size: 150,
-                        bottom: -30,
-                        left: -30,
-                        opacity: isDarkMode ? 0.1 : 0.03,
-                        usePrimaryColor: true,
-                      ),
-                      // Center-left bubble (small)
-                      AppTheme.bubble(
-                        context: context,
-                        size: 50,
-                        top: 100,
-                        left: 100,
-                        opacity: isDarkMode ? 0.08 : 0.02,
-                        usePrimaryColor: true,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+              const AppBackground(),
 
               SafeArea(
                 child: RefreshIndicator(

--- a/lib/screens/program/program_detail_screen.dart
+++ b/lib/screens/program/program_detail_screen.dart
@@ -6,7 +6,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:radio_odan_app/providers/program_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class ProgramDetailScreen extends StatefulWidget {
   const ProgramDetailScreen({super.key});
@@ -180,39 +180,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
           ),
           body: Stack(
             children: [
-              // Background gradient + bubbles
-              Positioned.fill(
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        Theme.of(context).primaryColor,
-                        Theme.of(context).scaffoldBackgroundColor,
-                      ],
-                    ),
-                  ),
-                  child: Stack(
-                    children: [
-                      AppTheme.bubble(context: context, size: 200, top: -50, right: -50),
-                      AppTheme.bubble(
-                        context: context,
-                        size: 150,
-                        bottom: -30,
-                        left: -30,
-                      ),
-                      AppTheme.bubble(
-                        context: context,
-                        size: 50,
-                        top: 100,
-                        left: 100,
-                        opacity: 0.05,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+              const AppBackground(),
 
               // Content states
               if (isLoading)
@@ -335,5 +303,4 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
     );
   }
 
-  // _bubble method removed - using AppTheme.bubble instead
 }

--- a/lib/screens/program/program_screen.dart
+++ b/lib/screens/program/program_screen.dart
@@ -7,8 +7,8 @@ import 'package:radio_odan_app/providers/program_provider.dart';
 import 'package:radio_odan_app/widgets/common/app_bar.dart';
 import 'package:radio_odan_app/widgets/common/mini_player.dart';
 import 'package:radio_odan_app/widgets/skeleton/all_programs_skeleton.dart';
-import 'package:radio_odan_app/config/app_theme.dart';
 import 'package:radio_odan_app/config/app_colors.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 // ⬇️ Import detail screen
 import 'package:radio_odan_app/screens/program/program_detail_screen.dart';
@@ -92,7 +92,6 @@ class _AllProgramsScreenState extends State<AllProgramsScreen>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDarkMode = theme.brightness == Brightness.dark;
     
     return Scaffold(
       appBar: CustomAppBar.transparent(
@@ -109,40 +108,7 @@ class _AllProgramsScreenState extends State<AllProgramsScreen>
       ),
       body: Stack(
         children: [
-          // Bubble/Wave Background
-          Positioned.fill(
-            child: Container(
-              color: theme.colorScheme.background,
-              child: Stack(
-                children: [
-                  AppTheme.bubble(
-                    context: context,
-                    size: 200,
-                    top: -50,
-                    right: -50,
-                    opacity: isDarkMode ? 0.1 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 150,
-                    bottom: -30,
-                    left: -30,
-                    opacity: isDarkMode ? 0.08 : 0.03,
-                    usePrimaryColor: true,
-                  ),
-                  AppTheme.bubble(
-                    context: context,
-                    size: 50,
-                    top: 100,
-                    left: 100,
-                    opacity: isDarkMode ? 0.06 : 0.02,
-                    usePrimaryColor: true,
-                  ),
-                ],
-              ),
-            ),
-          ),
+          const AppBackground(),
           // Main content
           _buildBody(),
           // Mini Player
@@ -151,8 +117,6 @@ class _AllProgramsScreenState extends State<AllProgramsScreen>
       ),
     );
   }
-
-  // _bubble method removed - using AppTheme.bubble instead
 
   Widget _buildBody() {
     return Consumer<ProgramProvider>(


### PR DESCRIPTION
## Summary
- replace per-screen gradient containers with const AppBackground for unified styling
- keep content widgets above AppBackground in stacks
- clean up unused theme imports and redundant color logic

## Testing
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1493f258832bb2240b26c56df554