### PR TITLE
Use AppBackground in not found screen

### DIFF
--- a/lib/screens/common/not_found_screen.dart
+++ b/lib/screens/common/not_found_screen.dart
@@ -1,52 +1,63 @@
 import 'package:flutter/material.dart';
+import 'package:radio_odan_app/widgets/common/app_background.dart';
 
 class NotFoundScreen extends StatelessWidget {
   const NotFoundScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
-      appBar: AppBar(title: const Text('404'), centerTitle: true),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.search_off,
-                size: 100,
-                color:
-                    Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
-              ),
-              const SizedBox(height: 24),
-              const Text(
-                'Halaman Tidak Ditemukan',
-                style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                'Maaf, halaman yang kamu tuju tidak tersedia atau argumennya tidak valid.',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onBackground
-                          .withOpacity(0.6),
+      appBar: AppBar(
+        title: Text('404', style: theme.textTheme.titleLarge),
+        centerTitle: true,
+      ),
+      body: Stack(
+        children: [
+          const AppBackground(),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.search_off,
+                    size: 100,
+                    color: theme.colorScheme.onSurface.withOpacity(0.6),
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Halaman Tidak Ditemukan',
+                    style: theme.textTheme.titleLarge
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Maaf, halaman yang kamu tuju tidak tersedia atau argumennya tidak valid.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onBackground.withOpacity(0.6),
+                        ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 32),
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).popUntil((route) => route.isFirst);
+                    },
+                    icon: const Icon(Icons.home),
+                    label: Text(
+                      'Kembali ke Beranda',
+                      style: theme.textTheme.labelLarge,
                     ),
-                textAlign: TextAlign.center,
+                  ),
+                ],
               ),
-              const SizedBox(height: 32),
-              ElevatedButton.icon(
-                onPressed: () {
-                  Navigator.of(context).popUntil((route) => route.isFirst);
-                },
-                icon: const Icon(Icons.home),
-                label: const Text('Kembali ke Beranda'),
-              ),
-            ],
+            ),
           ),
-        ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- include AppBackground in not found screen
- style not found texts via theme

## Testing
- `dart format lib/screens/common/not_found_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be18b02528832ba581451bac1e1a3d