### PR TITLE
Handle live chat listener lifecycle

### DIFF
--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -186,7 +186,9 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
-        await context.read<LiveChatProvider>().shutdown();
+        final prov = context.read<LiveChatProvider>();
+        await prov.leaveRoom();
+        await prov.shutdown();
         return true;
       },
       child: Consumer<LiveChatProvider>(
@@ -220,6 +222,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
               leading: IconButton(
                 icon: const Icon(Icons.arrow_back),
                 onPressed: () async {
+                  await prov.leaveRoom();
                   await prov.shutdown();
                   if (!mounted) return;
                   Navigator.pop(context, 'goHome');


### PR DESCRIPTION
## Summary
- join live chat listener on init and store listener ID
- leave listener on shutdown and when navigating away

## Testing
- ⚠️ `dart format lib/providers/live_chat_provider.dart lib/screens/chat/chat_screen.dart` (command not found)
- ⚠️ `flutter test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68be6e5f10d0832baec19c52cf7125e3