### PR TITLE
Fix live chat online user avatars

### DIFF
--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -145,14 +145,29 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                       final user = prov.onlineUsers[index];
                       return ListTile(
                         leading: CircleAvatar(
-                          backgroundColor: Theme.of(
-                            context,
-                          ).colorScheme.primary,
-                          child: Text(
-                            user.username.substring(0, 1).toUpperCase(),
-                            style: TextStyle(
-                              color: Theme.of(context).colorScheme.onPrimary,
-                            ),
+                          backgroundColor:
+                              Theme.of(context).colorScheme.surfaceVariant,
+                          child: ClipOval(
+                            child: (user.userAvatar != null &&
+                                    user.userAvatar!.trim().isNotEmpty)
+                                ? Image.network(
+                                    user.userAvatar!,
+                                    width: 40,
+                                    height: 40,
+                                    fit: BoxFit.cover,
+                                    errorBuilder: (_, __, ___) => Image.asset(
+                                      'assets/avatar.png',
+                                      width: 40,
+                                      height: 40,
+                                      fit: BoxFit.cover,
+                                    ),
+                                  )
+                                : Image.asset(
+                                    'assets/avatar.png',
+                                    width: 40,
+                                    height: 40,
+                                    fit: BoxFit.cover,
+                                  ),
                           ),
                         ),
                         title: Text(


### PR DESCRIPTION
## Summary
- Display online users' avatars in the live chat modal
- Use default avatar image when user avatar is missing

## Testing
- `dart format lib/screens/chat/chat_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9ad06f30832bbd8dc836615941f2