### PR TITLE
Fix presence user ID key

### DIFF
--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -341,7 +341,7 @@ class LiveChatSocketService {
           final users = hash.entries.map((entry) {
             final userId = _intOrString(entry.key);
             final user = _asMap(entry.value);
-            return {'id': userId, 'userInfo': user};
+            return {'userId': userId, 'userInfo': user};
           }).toList();
 
           // Kirim pesan sistem bahwa user telah bergabung


### PR DESCRIPTION
## Summary
- ensure presence subscription uses `userId` for member maps so providers receive correct IDs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9d7531ac832ba253c163856156ba