### PR TITLE
feat: ensure current user info updates online list

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -383,9 +383,37 @@ class LiveChatProvider with ChangeNotifier {
   // ==== SEND (HTTP; optimistic UI) ====
   final Set<String> _pendingMessageIds = {};
 
-  // Set current user ID after login
-  void setCurrentUserId(int userId) {
+  // Set current user info after login
+  void setCurrentUserId(
+    int userId, {
+    String? name,
+    String? avatar,
+  }) {
     _currentUserId = userId;
+
+    final idStr = userId.toString();
+    final index = _onlineUsers.indexWhere((u) => u.id == idStr);
+
+    if (index != -1) {
+      final existing = _onlineUsers[index];
+      _onlineUsers[index] = OnlineUser(
+        id: idStr,
+        username: name ?? existing.username,
+        userAvatar: avatar ?? existing.userAvatar,
+        joinTime: existing.joinTime,
+      );
+    } else {
+      _onlineUsers.add(
+        OnlineUser(
+          id: idStr,
+          username: name ?? 'User',
+          userAvatar: avatar,
+          joinTime: DateTime.now(),
+        ),
+      );
+    }
+
+    notifyListeners();
   }
 
   Future<void> send(

--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -38,9 +38,13 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
   void initState() {
     super.initState();
     _scrollController.addListener(_handleScroll);
-    final userId = context.read<UserProvider>().user?.id;
-    if (userId != null) {
-      context.read<LiveChatProvider>().setCurrentUserId(userId);
+    final user = context.read<UserProvider>().user;
+    if (user != null) {
+      context.read<LiveChatProvider>().setCurrentUserId(
+            user.id,
+            name: user.name,
+            avatar: user.avatarUrl.isNotEmpty ? user.avatarUrl : null,
+          );
     }
   }
 


### PR DESCRIPTION
## Summary
- extend live chat provider to capture current user name and avatar
- populate live chat provider from ChatScreen using UserProvider details

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9e317234832baaa6718788679375