### PR TITLE
Use primary color for transparent app bar

### DIFF
--- a/lib/widgets/common/app_bar.dart
+++ b/lib/widgets/common/app_bar.dart
@@ -58,8 +58,8 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       title: title,
       backgroundColor: AppColors.transparent,
       elevation: 0,
-      titleColor: titleColor ?? colors.onSurface,
-      iconColor: iconColor ?? colors.onSurface,
+      titleColor: titleColor ?? colors.primary,
+      iconColor: iconColor ?? colors.primary,
       actions: actions,
       leading: leading,
       flexibleSpace: showGradient
@@ -164,10 +164,10 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  // Tombol back selalu kontras: pakai primary/onPrimary dari ColorScheme
+  // Tombol back dengan ikon berwarna primary dan latar transparan
   Widget _buildModernBackButton(BuildContext context, ColorScheme colors) {
-    final bg = colors.primary;
-    final fg = colors.onPrimary;
+    final fg = colors.primary;
+    const bg = AppColors.transparent;
 
     return IconButton(
       onPressed: () => Navigator.maybePop(context),


### PR DESCRIPTION
## Summary
- default to primary color for titles and icons in the transparent app bar variant
- style modern back button with primary-colored icon on transparent background

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bea0aa537c832b97e9ab6168f55471