### PR TITLE
Use primary blue CustomAppBar in chat screen

### DIFF
--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -217,9 +217,7 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
             return Scaffold(
               appBar: CustomAppBar(
                 title: 'Live Chat',
-                backgroundColor: colors.surface,
-                titleColor: colors.primary,
-                iconColor: colors.primary,
+                backgroundColor: colors.primary,
               ),
               body: const Center(child: CircularProgressIndicator()),
             );
@@ -244,11 +242,9 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
           return Scaffold(
             appBar: CustomAppBar(
               title: prov.isLive ? 'Live Chat - ON AIR' : 'Live Chat',
-              backgroundColor: colors.surface,
-              titleColor: colors.primary,
-              iconColor: colors.primary,
+              backgroundColor: colors.primary,
               leading: IconButton(
-                icon: Icon(Icons.arrow_back, color: colors.primary),
+                icon: const Icon(Icons.arrow_back),
                 onPressed: () async {
                   await prov.leaveRoom();
                   await prov.shutdown();


### PR DESCRIPTION
## Summary
- replace loading and main chat AppBars with CustomAppBar using the primary color
- use default onPrimary icon/text colors for back and action buttons

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bea1b36ecc832b8897cddabca6c3f9