### PR TITLE
Use primary background for transparent app bar

### DIFF
--- a/lib/widgets/common/app_bar.dart
+++ b/lib/widgets/common/app_bar.dart
@@ -49,17 +49,17 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     Color? titleColor,
     Color? iconColor,
     required BuildContext context,
-    bool showGradient = true,
+    bool showGradient = false,
   }) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
 
     return CustomAppBar(
       title: title,
-      backgroundColor: AppColors.transparent,
+      backgroundColor: colors.primary,
       elevation: 0,
-      titleColor: titleColor ?? colors.primary,
-      iconColor: iconColor ?? colors.primary,
+      titleColor: titleColor ?? colors.onPrimary,
+      iconColor: iconColor ?? colors.onPrimary,
       actions: actions,
       leading: leading,
       flexibleSpace: showGradient
@@ -150,7 +150,9 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       actionsIconTheme: IconThemeData(color: effectiveIconColor, size: 24),
       leading:
           leading ??
-          (showBackButton ? _buildModernBackButton(context, colors) : null),
+          (showBackButton
+              ? _buildModernBackButton(context, colors, effectiveIconColor)
+              : null),
       leadingWidth: showBackButton ? 56 : null,
       actions: actions != null
           ? [
@@ -164,9 +166,9 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  // Tombol back dengan ikon berwarna primary dan latar transparan
-  Widget _buildModernBackButton(BuildContext context, ColorScheme colors) {
-    final fg = colors.primary;
+  // Tombol back modern dengan latar transparan
+  Widget _buildModernBackButton(
+      BuildContext context, ColorScheme colors, Color fg) {
     const bg = AppColors.transparent;
 
     return IconButton(


### PR DESCRIPTION
## Summary
- Give CustomAppBar.transparent a primary color background
- Keep title and navigation icons readable on primary background
- Back button now adopts the effective icon color

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea1a5e2a0832b9072448411cdf23f