### PR TITLE
refactor: handle null values safely

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -326,8 +326,8 @@ class LiveChatProvider with ChangeNotifier {
 
     // Debounce rapid successive calls
     final now = DateTime.now();
-    if (_lastFetchTime != null &&
-        now.difference(_lastFetchTime!) < _fetchCooldown) {
+    final lastFetch = _lastFetchTime;
+    if (lastFetch != null && now.difference(lastFetch) < _fetchCooldown) {
       return;
     }
 
@@ -496,9 +496,10 @@ class LiveChatProvider with ChangeNotifier {
 
   // ==== LIFECYCLE ====
   Future<void> leaveRoom() async {
-    if (_listenerId == null) return;
+    final id = _listenerId;
+    if (id == null) return;
     try {
-      await _http.leaveListener(_listenerId!);
+      await _http.leaveListener(id);
     } catch (_) {}
     _listenerId = null;
   }

--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -148,15 +148,15 @@ class _LiveChatScreenState extends State<LiveChatScreen> {
                     itemCount: prov.onlineUsers.length,
                     itemBuilder: (context, index) {
                       final user = prov.onlineUsers[index];
+                      final avatarUrl = user.userAvatar?.trim();
                       return ListTile(
                         leading: CircleAvatar(
                           backgroundColor:
                               Theme.of(context).colorScheme.surfaceVariant,
                           child: ClipOval(
-                            child: (user.userAvatar != null &&
-                                    user.userAvatar!.trim().isNotEmpty)
+                            child: (avatarUrl != null && avatarUrl.isNotEmpty)
                                 ? Image.network(
-                                    user.userAvatar!,
+                                    avatarUrl,
                                     width: 40,
                                     height: 40,
                                     fit: BoxFit.cover,

--- a/lib/widgets/common/mini_player.dart
+++ b/lib/widgets/common/mini_player.dart
@@ -46,14 +46,17 @@ class _MiniPlayerState extends State<MiniPlayer> {
         radioProvider.currentStation ?? RadioStationProvider.defaultStation;
     final nowPlaying = radioProvider.nowPlaying;
 
-    final cover = (nowPlaying?.artUrl.isNotEmpty ?? false)
-        ? nowPlaying!.artUrl
+    final artUrl = nowPlaying?.artUrl;
+    final cover = (artUrl != null && artUrl.isNotEmpty)
+        ? artUrl
         : currentStation.coverUrl;
-    final title = (nowPlaying?.title.isNotEmpty ?? false)
-        ? nowPlaying!.title
+    final nowTitle = nowPlaying?.title;
+    final title = (nowTitle != null && nowTitle.isNotEmpty)
+        ? nowTitle
         : currentStation.title;
-    final artist = (nowPlaying?.artist.isNotEmpty ?? false)
-        ? nowPlaying!.artist
+    final nowArtist = nowPlaying?.artist;
+    final artist = (nowArtist != null && nowArtist.isNotEmpty)
+        ? nowArtist
         : currentStation.host;
 
     return GestureDetector(


### PR DESCRIPTION
## Summary
- avoid non-null assertions in loadMore and leaveRoom
- handle nullable user avatars gracefully on chat screen
- guard mini player metadata against nulls

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea74b0e2c832bb4eec5268772e3b5