### PR TITLE
feat: load like counts from global status

### DIFF
--- a/lib/services/live_chat_service.dart
+++ b/lib/services/live_chat_service.dart
@@ -61,9 +61,9 @@ class LiveChatService {
         'title': liveRoom['judul'],
         'description': liveRoom['description'],
         'started_at': liveRoom['started_at'],
-        'likes': 0,
-        'liked': false,
-        'listener_count': 0,
+        'likes': _toInt(liveRoom['likes'] ?? data['likes'] ?? 0),
+        'liked': liveRoom['liked'] ?? data['liked'] ?? false,
+        'listener_count': _toInt(data['listener_count'] ?? 0),
         // tambahkan room_id agar provider bisa tahu channel chat
         'room_id': liveRoom['id'],
       });


### PR DESCRIPTION
## Summary
- fetch likes, liked state, and listener count from global status API

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed569c948832b9555af8da4447ff9