### PR TITLE
Handle additional success responses in toggleLike

### DIFF
--- a/lib/services/live_chat_service.dart
+++ b/lib/services/live_chat_service.dart
@@ -251,9 +251,17 @@ class LiveChatService {
       );
       final code = res.statusCode ?? 0;
       final body = _asMap(res.data);
+      final src = _asMap(body['data'] ?? body);
+      final ok = body['success'] == true ||
+          body['status'] == true ||
+          src.containsKey('liked') ||
+          src.containsKey('likes');
 
-      if (code == 200 && body['success'] == true) {
-        return {'liked': body['liked'] == true, 'likes': _toInt(body['likes'])};
+      if (code == 200 && ok) {
+        return {
+          'liked': src['liked'] == true,
+          'likes': _toInt(src['likes']),
+        };
       }
       if (code == 401 || code == 403) {
         throw Exception('Unauthorized');


### PR DESCRIPTION
## Summary
- broaden success criteria in `toggleLike` to recognize `status` responses or direct `liked/likes` fields
- ensure liked count and state read from response body or `data`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed7321a00832ba759a457edacbfd4