### PR TITLE
Skip anonymous users in live chat

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -126,6 +126,7 @@ class LiveChatProvider with ChangeNotifier {
       onUserJoined: (channel, user) {
         final map = (user);
         final id = (map['userId'] ?? '').toString();
+        if (id.isEmpty) return;
         if (_onlineUsers.indexWhere((x) => x.id == id) == -1) {
           final username =
               (map['userInfo']?['name'] ??


### PR DESCRIPTION
## Summary
- avoid adding online users when the received ID is empty to prevent null entries

## Testing
- `dart format lib/providers/live_chat_provider.dart` (fails: command not found)
- `apt-get update` (fails: repository not signed)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bf099cbea0832bbffce9d22c4a016c