### PR TITLE
Filter online users lacking ID

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -257,7 +257,10 @@ class LiveChatProvider with ChangeNotifier {
           final onlineUsers = await _http.getOnlineUsers(roomId);
           _onlineUsers.clear();
           _onlineUsers.addAll(
-            onlineUsers.map((user) {
+            onlineUsers
+                .where((u) =>
+                    u['id'] != null && u['id'].toString().isNotEmpty)
+                .map((user) {
               final rawAvatar = user['avatar']?.toString().trim();
               String? avatarUrl;
               if (rawAvatar != null && rawAvatar.isNotEmpty) {


### PR DESCRIPTION
## Summary
- skip adding online users without an id in `LiveChatProvider`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a2daae0832b89531c4545f366ad