### PR TITLE
Clean up placeholder users when setting current user ID

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -440,6 +440,8 @@ class LiveChatProvider with ChangeNotifier {
       );
     }
 
+    _onlineUsers.removeWhere((u) => u.id.isEmpty);
+
     notifyListeners();
   }
 


### PR DESCRIPTION
## Summary
- Remove empty-ID placeholder users after updating or adding current user info

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0abc192c832b8fb9eb3233c740c1