### PR TITLE
Ignore invalid user IDs in live chat

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -150,7 +150,7 @@ class LiveChatProvider with ChangeNotifier {
       onUserJoined: (channel, user) {
         final map = (user);
         final id = (map['userId'] ?? '').toString();
-        if (id.isEmpty) return;
+        if (id.isEmpty || id == '0') return;
         if (_onlineUsers.indexWhere((x) => x.id == id) == -1) {
           final username =
               (map['userInfo']?['name'] ??


### PR DESCRIPTION
## Summary
- avoid processing join events when the user ID is empty or '0'

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf10333108832bb29705512c484a2b