### PR TITLE
Remove placeholder users with empty or zero IDs

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -475,7 +475,7 @@ class LiveChatProvider with ChangeNotifier {
       );
     }
 
-    _onlineUsers.removeWhere((u) => u.id.isEmpty);
+    _onlineUsers.removeWhere((u) => u.id.isEmpty || u.id == '0');
 
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- avoid retaining placeholder users with empty or zero IDs in LiveChatProvider

## Testing
- `dart format lib/providers/live_chat_provider.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bf1142e8b0832b90eaf8dd9d9ea900