### PR TITLE
fix: filter invalid online user ids

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -297,7 +297,9 @@ class LiveChatProvider with ChangeNotifier {
           _onlineUsers.addAll(
             onlineUsers
                 .where((u) =>
-                    u['id'] != null && u['id'].toString().isNotEmpty)
+                    u['id'] != null &&
+                    u['id'].toString().isNotEmpty &&
+                    u['id'].toString() != '0')
                 .map((user) {
               final rawAvatar = user['avatar']?.toString().trim();
               String? avatarUrl;


### PR DESCRIPTION
## Summary
- tighten online user filtering to exclude `id == '0'`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf11ef12c8832b957048ac1101cb74