### PR TITLE
Handle invalid user IDs in presence events

### DIFF
--- a/lib/services/live_chat_socket_service.dart
+++ b/lib/services/live_chat_socket_service.dart
@@ -680,8 +680,9 @@ class LiveChatSocketService {
       final userData = _asMap(payload['user'] ?? payload['data'] ?? payload);
       final userInfo = _asMap(userData['userInfo'] ?? userData);
 
+      final uid = _toInt(userData['userId'] ?? userData['id']);
       final processedUser = <String, dynamic>{
-        'userId': _toInt(userData['userId'] ?? userData['id']).toString(),
+        'userId': uid > 0 ? uid.toString() : '',
         'userInfo': {
           'name': userInfo['name']?.toString() ?? 'Unknown User',
           'avatar': userInfo['avatar']?.toString(),


### PR DESCRIPTION
## Summary
- ensure presence events provide empty string for invalid user IDs

## Testing
- `dart format lib/services/live_chat_socket_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bf130f635c832b8e1570f74ac5f271