### PR TITLE
Await deep link handler initialization

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -55,7 +55,7 @@ class _RadioAppState extends State<RadioApp> {
     
     // Initialize deep links after a short delay to ensure context is ready
     await Future.delayed(const Duration(milliseconds: 100));
-    _deepLinkHandler.init();
+    await _deepLinkHandler.init();
     
     // Check for initial deep link
     if (mounted) {


### PR DESCRIPTION
## Summary
- ensure deep link handler initialization is awaited in app startup

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00e10be88832bbc21ca08ea228137