### PR TITLE
Ignore Android keystore properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Keystore file
+/android/key.properties

--- a/android/key.properties
+++ b/android/key.properties
@@ -1,4 +1,0 @@
-storeFile=keystore.jks
-storePassword=your-store-password
-keyAlias=your-key-alias
-keyPassword=your-key-password


### PR DESCRIPTION
## Summary
- ignore `android/key.properties` in git
- remove tracked keystore file

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dc1a7394832b8f2307fdde1e6d1c