### PR TITLE
refactor: switch env to dart defines

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:just_audio_background/just_audio_background.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -127,8 +128,10 @@ Future<void> initializeApp() async {
   // This will suppress the locale warnings
   await Firebase.app().setAutomaticDataCollectionEnabled(true);
 
-  // Load environment variables
-  await dotenv.load(fileName: ".env");
+  // Load local environment variables only for non-release builds
+  if (!kReleaseMode) {
+    await dotenv.load(fileName: ".env");
+  }
 
   // Initialize API client with base URL from environment
   await ApiClient.I.ensureInterceptors();

--- a/lib/config/app_api_config.dart
+++ b/lib/config/app_api_config.dart
@@ -1,19 +1,17 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-class AppApiConfig {
-  static String get apiBaseUrl {
-    final url = dotenv.maybeGet('API_BASE_URL');
-    if (url == null || url.isEmpty) {
-      throw Exception("API_BASE_URL tidak ditemukan di .env");
-    }
-    return url;
+String _readEnv(String key) {
+  final defined = const String.fromEnvironment(key);
+  if (defined.isNotEmpty) return defined;
+  final value = dotenv.maybeGet(key);
+  if (value == null || value.isEmpty) {
+    throw Exception("$key tidak ditemukan di konfigurasi");
   }
+  return value;
+}
 
-  static String get assetBaseUrl {
-    final url = dotenv.maybeGet('ASSET_BASE_URL');
-    if (url == null || url.isEmpty) {
-      throw Exception("ASSET_BASE_URL tidak ditemukan di .env");
-    }
-    return url;
-  }
+class AppApiConfig {
+  static String get apiBaseUrl => _readEnv('API_BASE_URL');
+
+  static String get assetBaseUrl => _readEnv('ASSET_BASE_URL');
 }

--- a/lib/config/pusher_config.dart
+++ b/lib/config/pusher_config.dart
@@ -1,28 +1,32 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-class PusherConfig {
-  static String get appKey {
-    final key = dotenv.maybeGet('PUSHER_APP_KEY')?.trim();
-    if (key == null || key.isEmpty) {
-      throw Exception('PUSHER_APP_KEY tidak ditemukan di .env');
-    }
-    return key;
+String _readEnv(String key) {
+  final defined = const String.fromEnvironment(key);
+  if (defined.isNotEmpty) return defined.trim();
+  final value = dotenv.maybeGet(key)?.trim();
+  if (value == null || value.isEmpty) {
+    throw Exception('$key tidak ditemukan di konfigurasi');
   }
+  return value;
+}
 
-  static String get cluster {
-    final cluster = dotenv.maybeGet('PUSHER_CLUSTER')?.trim();
-    if (cluster == null || cluster.isEmpty) {
-      throw Exception('PUSHER_CLUSTER tidak ditemukan di .env');
-    }
-    return cluster;
-  }
+class PusherConfig {
+  static String get appKey => _readEnv('PUSHER_APP_KEY');
+
+  static String get cluster => _readEnv('PUSHER_CLUSTER');
 
   static String get authEndpoint {
-    final raw = (dotenv.maybeGet('PUSHER_AUTH_ENDPOINT') ?? '').trim();
+    final raw = _readOptional('PUSHER_AUTH_ENDPOINT');
     if (raw.isEmpty) {
       return 'https://odanfm.batubarakab.go.id/api/broadcasting/auth';
     }
     if (raw.startsWith('http')) return raw;
     return 'https://odanfm.batubarakab.go.id${raw.startsWith('/') ? raw : '/$raw'}';
   }
+}
+
+String _readOptional(String key) {
+  final defined = const String.fromEnvironment(key);
+  if (defined.isNotEmpty) return defined.trim();
+  return dotenv.maybeGet(key)?.trim() ?? '';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,7 +76,6 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
-    - .env
 
 # Configure app launcher icon
 flutter_icons:


### PR DESCRIPTION
## Summary
- avoid bundling `.env` by removing it from assets
- load `.env` only for non-release builds
- pull config values from `--dart-define` or `.env`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dc271c28832bbc80a2db88ee0984