### PR TITLE
Specify URI type for deep link subscription

### DIFF
--- a/lib/utils/deep_link_handler.dart
+++ b/lib/utils/deep_link_handler.dart
@@ -6,7 +6,7 @@ import 'package:radio_odan_app/config/app_routes.dart';
 typedef DeepLinkCallback = void Function(Uri uri);
 
 class DeepLinkHandler {
-  StreamSubscription? _sub;
+  StreamSubscription<Uri?>? _sub;
   DeepLinkCallback? _onDeepLink;
   GlobalKey<NavigatorState>? _navigatorKey;
   final AppLinks _appLinks = AppLinks();


### PR DESCRIPTION
## Summary
- type deep link handler stream subscription as `StreamSubscription<Uri?>`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e41e199c832b8f168b3cc9653d6b