### PR TITLE
refactor: centralize audio source reset

### DIFF
--- a/lib/audio/audio_player_manager.dart
+++ b/lib/audio/audio_player_manager.dart
@@ -39,14 +39,18 @@ class AudioPlayerManager {
         ),
       );
 
-      await _player.setAudioSource(
-        AudioSource.uri(Uri.parse('')),
-        preload: false,
-      );
+      await _resetAudioSource();
     } catch (e) {
       log('Error setting up audio session: $e');
       rethrow;
     }
+  }
+
+  Future<void> _resetAudioSource() async {
+    await _player.setAudioSource(
+      AudioSource.uri(Uri.parse('')),
+      preload: false,
+    );
   }
 
   AudioPlayer get player => _player;
@@ -80,10 +84,7 @@ class AudioPlayerManager {
       );
 
       try {
-        await _player.setAudioSource(
-          AudioSource.uri(Uri.parse('')),
-          preload: false,
-        );
+        await _resetAudioSource();
 
         await _player.setAudioSource(
           audioSource,
@@ -137,15 +138,7 @@ class AudioPlayerManager {
       }
 
       await _player.pause();
-
-      await _player.setAudioSource(
-        AudioSource.uri(Uri.parse('')),
-        preload: false,
-      );
-      await _player.setAudioSource(
-        AudioSource.uri(Uri.parse('')),
-        preload: false,
-      );
+      await _resetAudioSource();
 
       await _player.stop();
 


### PR DESCRIPTION
## Summary
- centralize audio source resetting to a helper
- remove duplicate audio source reset in stop

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e42f900c832ba99d004631c5e358