### PR TITLE
Stop audio on logout

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -8,6 +8,7 @@ import 'package:firebase_auth/firebase_auth.dart' as fb;
 import 'package:radio_odan_app/models/user_model.dart';
 import 'package:radio_odan_app/services/auth_service.dart';
 import 'package:radio_odan_app/config/api_client.dart';
+import 'package:radio_odan_app/audio/audio_player_manager.dart';
 
 class AuthProvider with ChangeNotifier {
   UserModel? _user;
@@ -176,6 +177,7 @@ class AuthProvider with ChangeNotifier {
     try {
       await AuthService.I.logout();
     } finally {
+      await AudioPlayerManager.instance.stop();
       await const FlutterSecureStorage().delete(key: 'user_token');
       _user = null;
       _token = null;


### PR DESCRIPTION
## Summary
- stop audio playback when a user logs out

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f50f1ae8832b9eb5379b89e7c208