### PR TITLE
Use AuthProvider for drawer logout

### DIFF
--- a/lib/widgets/common/app_drawer.dart
+++ b/lib/widgets/common/app_drawer.dart
@@ -3,10 +3,10 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:provider/provider.dart';
 
 import 'package:radio_odan_app/models/user_model.dart';
+import 'package:radio_odan_app/providers/auth_provider.dart';
 import 'package:radio_odan_app/providers/user_provider.dart';
 import 'package:radio_odan_app/providers/theme_provider.dart';
 import 'package:radio_odan_app/config/app_routes.dart';
-import 'package:radio_odan_app/services/user_service.dart';
 
 class AppDrawer extends StatelessWidget {
   const AppDrawer({super.key});
@@ -159,7 +159,9 @@ class AppDrawer extends StatelessWidget {
                                   title: "Logout",
                                   iconColor: colorScheme.error,
                                   onTap: () async {
-                                    await UserService.logout();
+                                    await context
+                                        .read<AuthProvider>()
+                                        .logout();
                                     if (context.mounted) {
                                       Navigator.pushNamedAndRemoveUntil(
                                         context,


### PR DESCRIPTION
## Summary
- use `AuthProvider.logout` via context in app drawer
- remove old `UserService.logout` and keep navigation to login

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f5b05e88832ba92b2bfd81678f09