### PR TITLE
Keep global socket connection when closing chat

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -605,7 +605,7 @@ class LiveChatProvider with ChangeNotifier {
     _listenerId = null;
   }
 
-  Future<void> shutdown() async {
+  Future<void> shutdown({bool disconnectSocket = false}) async {
     await leaveRoom();
     try {
       await _sock.unsubscribePublic(_currentRoomId ?? roomId);
@@ -613,11 +613,15 @@ class LiveChatProvider with ChangeNotifier {
     try {
       await _sock.unsubscribePresence(roomId);
     } catch (_) {}
-    try {
-      await _sock.unsubscribeStatus();
-    } catch (_) {}
-    try {
-      await _sock.disconnect();
-    } catch (_) {}
+
+    // Keep global status subscription and socket connection alive by default
+    if (disconnectSocket) {
+      try {
+        await _sock.unsubscribeStatus();
+      } catch (_) {}
+      try {
+        await _sock.disconnect();
+      } catch (_) {}
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Keep Pusher connection and `live-room-status` subscription active by default when shutting down `LiveChatProvider`
- Allow optional full disconnect via `shutdown(disconnectSocket: true)`

## Testing
- `dart analyze lib/providers/live_chat_provider.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c12a5de578832ba8b4ab649315707f