### PR TITLE
Refresh live status on navigation and resume

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -85,6 +85,8 @@ class _RadioAppState extends State<RadioApp> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.detached) {
       AudioPlayerManager.instance.stop();
+    } else if (state == AppLifecycleState.resumed) {
+      Provider.of<LiveStatusProvider>(context, listen: false).refresh();
     }
   }
 

--- a/lib/navigation/bottom_nav.dart
+++ b/lib/navigation/bottom_nav.dart
@@ -101,6 +101,7 @@ class _BottomNavState extends State<BottomNav> {
             currentIndex: _currentIndex,
             onTap: (index) async {
               if (index == 3) {
+                await liveStatus.refresh();
                 await Navigator.of(
                   context,
                 ).push(ChatScreenWrapper.route(liveStatus.roomId));

--- a/lib/navigation/chat_screen_wrapper.dart
+++ b/lib/navigation/chat_screen_wrapper.dart
@@ -30,6 +30,7 @@ class _ChatScreenWrapperState extends State<ChatScreenWrapper> {
     _statusProvider = Provider.of<LiveStatusProvider>(context, listen: false);
     _statusProvider.addListener(_handleStatusChange);
     _handleStatusChange(initial: true);
+    _statusProvider.refresh();
   }
 
   void _handleStatusChange({bool initial = false}) {

--- a/lib/providers/live_status_provider.dart
+++ b/lib/providers/live_status_provider.dart
@@ -18,7 +18,7 @@ class LiveStatusProvider with ChangeNotifier {
   }
 
   void _init() {
-    _fetchInitialStatus();
+    refresh();
     _socket.statusStream.listen((data) {
       final started = data['status'] == 'started' || data['is_live'] == true;
       final rid = data['room_id'] ?? data['roomId'];
@@ -28,7 +28,7 @@ class LiveStatusProvider with ChangeNotifier {
     });
   }
 
-  Future<void> _fetchInitialStatus() async {
+  Future<void> refresh() async {
     try {
       final status = await _http.fetchGlobalStatus();
       _isLive = status.isLive;

--- a/lib/screens/player/player_screen.dart
+++ b/lib/screens/player/player_screen.dart
@@ -87,6 +87,7 @@ class _FullPlayerState extends State<FullPlayer> {
     _statusProvider = Provider.of<LiveStatusProvider>(context, listen: false);
     _statusProvider.addListener(_handleStatusChange);
     _handleStatusChange();
+    _statusProvider.refresh();
   }
 
   // ====== Helpers UI ======


### PR DESCRIPTION
## Summary
- expose `refresh()` on `LiveStatusProvider`
- refresh live status on app resume and when entering chat/player screens
- update bottom navigation chat tap to trigger a refresh

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c12c2213c4832bbc5af9c0fa31745e