### PR TITLE
Handle liveRoomId updates for new live sessions

### DIFF
--- a/lib/providers/live_chat_provider.dart
+++ b/lib/providers/live_chat_provider.dart
@@ -122,8 +122,13 @@ class LiveChatProvider with ChangeNotifier {
         }
 
         // update roomId jika dikirim
-        final rid = data['roomId'] ?? data['room_id'];
-        if (rid is int) _currentRoomId = rid;
+        final rid =
+            data['roomId'] ?? data['room_id'] ?? data['liveRoomId'];
+        if (rid is int) {
+          _currentRoomId = rid;
+        } else if (rid is String) {
+          _currentRoomId = int.tryParse(rid);
+        }
 
         // saat live start → subscribe chat + tarik history awal
         _page = 1;

--- a/lib/providers/live_status_provider.dart
+++ b/lib/providers/live_status_provider.dart
@@ -21,7 +21,7 @@ class LiveStatusProvider with ChangeNotifier {
     refresh();
     _socket.statusStream.listen((data) {
       final started = data['status'] == 'started' || data['is_live'] == true;
-      final rid = data['room_id'] ?? data['roomId'];
+      final rid = data['room_id'] ?? data['roomId'] ?? data['liveRoomId'];
       _isLive = started;
       _roomId = started ? _parseInt(rid) : null;
       notifyListeners();


### PR DESCRIPTION
## Summary
- update live status provider to parse `liveRoomId`
- ensure live chat provider sets `_currentRoomId` from `liveRoomId`

## Testing
- `flutter test` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_68c13069166c832b83273019b84e1e27